### PR TITLE
autogen.sh: should use bash instead of sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 srcdir=`dirname $0`
 test -z "$srcdir" && srcidr=.


### PR DESCRIPTION
in debian derived distro (in about recent 7-10 years) including
pervasive accessible ubuntu , the default sh is `dash` instead of
`bash`, and provides much less features than `bash`.

if run `autogen.sh` on ubuntu, will cause

    $ ./autogen.sh
    ./autogen.sh: 8: ./autogen.sh: function: not found

We should use `bash` explicitly.
