### PR TITLE
autogen.sh: should not use bash keyword, "function"

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,7 +5,7 @@ test -z "$srcdir" && srcidr=.
 
 cd $srcdir
 
-function die
+die()
 {
 	echo
 	echo "$1"


### PR DESCRIPTION
in debian derived distro (in about recent 7-10 years) including
pervasive accessible ubuntu , the default sh is dash instead of
bash, and provide much less features than bash.

if run autogen.sh on ubuntu, will cause

    $ ./autogen.sh
    ./autogen.sh: 8: ./autogen.sh: function: not found

we should avoid to use the bash-only feature.
