### PR TITLE
Init tty connection before container run

### DIFF
--- a/client/hijack.go
+++ b/client/hijack.go
@@ -54,7 +54,7 @@ func (cli *HyperClient) hijack(method, path string, setRawTerminal bool, in io.R
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
-			return fmt.Errorf("Cannot connect to the Docker daemon. Is 'docker' running on this host?")
+			return fmt.Errorf("Cannot connect to the Hyper daemon. Is 'hyperd' running on this host?")
 		}
 		return err
 	}

--- a/client/replace.go
+++ b/client/replace.go
@@ -57,7 +57,7 @@ func (cli *HyperClient) HyperCmdReplace(args ...string) error {
 		return fmt.Errorf("Error code is %d, cause is %s", code, cause)
 	}
 	if newPodId != "" {
-		if _, err := cli.StartPod(newPodId, vmId); err != nil {
+		if _, err := cli.StartPod(newPodId, vmId, false); err != nil {
 			return err
 		}
 		fmt.Printf("Successfully replaced the old pod(%s) with new pod(%s)\n", oldPodId, newPodId)
@@ -82,7 +82,7 @@ func (cli *HyperClient) HyperCmdReplace(args ...string) error {
 		if err != nil {
 			return err
 		}
-		if _, err := cli.StartPod(newPodId, vmId); err != nil {
+		if _, err := cli.StartPod(newPodId, vmId, false); err != nil {
 			return err
 		}
 		fmt.Printf("Successfully replaced the old pod(%s) with new pod file(%s)\n", oldPodId, newPodFile)

--- a/client/utils.go
+++ b/client/utils.go
@@ -225,7 +225,7 @@ func (cli *HyperClient) resizeTty(id, tag string) {
 	}
 }
 func (cli *HyperClient) monitorTtySize(id, tag string) error {
-	cli.resizeTty(id, tag)
+	//cli.resizeTty(id, tag)
 
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, syscall.SIGWINCH)

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"github.com/hyperhq/hyper/engine"
+	"github.com/hyperhq/runv/hypervisor/types"
 	"github.com/hyperhq/runv/lib/glog"
 )
 
@@ -41,7 +42,8 @@ func (daemon *Daemon) CmdAttach(job *engine.Job) (err error) {
 		return fmt.Errorf("Can find VM whose Id is %s!", vmId)
 	}
 
-	err = vm.Attach(job.Stdin, job.Stdout, tag, container, nil)
+	ttyCallback := make(chan *types.VmResponse, 1)
+	err = vm.Attach(job.Stdin, job.Stdout, tag, container, ttyCallback, nil)
 	if err != nil {
 		return err
 	}
@@ -49,6 +51,8 @@ func (daemon *Daemon) CmdAttach(job *engine.Job) (err error) {
 	defer func() {
 		glog.V(2).Info("Defer function for exec!")
 	}()
+
+	<-ttyCallback
 
 	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -382,6 +382,31 @@ func (daemon *Daemon) WritePodToDB(podName string, podData []byte) error {
 	return nil
 }
 
+func (daemon *Daemon) GetPod(podId, podArgs string, autoremove bool) (mypod *hypervisor.Pod, podData []byte, err error) {
+	if podArgs == "" {
+		var ok bool
+		if mypod, ok = daemon.PodList[podId]; !ok {
+			return nil, []byte{}, fmt.Errorf("Can not find the POD instance of %s", podId)
+		}
+
+		podData, err = daemon.GetPodByName(podId)
+		if err != nil {
+			return nil, []byte{}, err
+		}
+	} else {
+		podData = []byte(podArgs)
+
+		if err = daemon.CreatePod(podId, podArgs, nil, autoremove); err != nil {
+			glog.Error(err.Error())
+			return nil, []byte{}, err
+		}
+
+		mypod = daemon.PodList[podId]
+	}
+
+	return mypod, podData, nil
+}
+
 func (daemon *Daemon) GetPodByName(podName string) ([]byte, error) {
 	key := fmt.Sprintf("pod-%s", podName)
 	data, err := daemon.db.Get([]byte(key), nil)

--- a/daemon/vm.go
+++ b/daemon/vm.go
@@ -13,7 +13,6 @@ import (
 
 func (daemon *Daemon) CmdVmCreate(job *engine.Job) (err error) {
 	var (
-		vmId = fmt.Sprintf("vm-%s", pod.RandStr(10, "alpha"))
 		vm   *hypervisor.Vm
 		cpu  = 1
 		mem  = 128
@@ -33,16 +32,25 @@ func (daemon *Daemon) CmdVmCreate(job *engine.Job) (err error) {
 		}
 	}
 
-	vm, err = daemon.StartVm(vmId, cpu, mem, false, 0)
+	vm, err = daemon.StartVm("", cpu, mem, false, 0)
 	if err != nil {
 		return err
 	}
 
-	daemon.AddVm(vm)
+	defer func() {
+		if err != nil {
+			daemon.KillVm(vm.Id)
+		}
+	}()
+
+	err = daemon.WaitVmStart(vm)
+	if err != nil {
+		return err
+	}
 
 	// Prepare the VM status to client
 	v := &engine.Env{}
-	v.Set("ID", vmId)
+	v.Set("ID", vm.Id)
 	v.SetInt("Code", 0)
 	v.Set("Cause", "")
 	if _, err := v.WriteTo(job.Stdout); err != nil {
@@ -138,6 +146,14 @@ func (daemon *Daemon) ReleaseAllVms() (int, error) {
 }
 
 func (daemon *Daemon) StartVm(vmId string, cpu, mem int, lazy bool, keep int) (*hypervisor.Vm, error) {
+	var (
+		DEFAULT_CPU = 1
+		DEFAULT_MEM = 128
+	)
+
+	if cpu <= 0 { cpu = DEFAULT_CPU }
+	if mem <= 0 { mem = DEFAULT_MEM }
+
 	b := &hypervisor.BootConfig{
 		CPU:    cpu,
 		Memory: mem,
@@ -150,45 +166,49 @@ func (daemon *Daemon) StartVm(vmId string, cpu, mem int, lazy bool, keep int) (*
 
 	vm := daemon.NewVm(vmId, cpu, mem, lazy, keep)
 
+	glog.V(1).Infof("The config: kernel=%s, initrd=%s", daemon.Kernel, daemon.Initrd)
 	err := vm.Launch(b)
 	if err != nil {
 		return nil, err
 	}
-	_, r1, r2, err1 := vm.GetVmChan()
-	if err1 != nil {
-		return nil, err1
-	}
-	vmStatus := r1.(chan *types.VmResponse)
-	subVmStatus := r2.(chan *types.VmResponse)
-	go func(interface{}) {
-		defer func() {
-			err := recover()
-			if err != nil {
-				glog.Warning("panic during send shutdown message to channel")
-			}
-		}()
-		for {
-			vmResponse := <-vmStatus
-			subVmStatus <- vmResponse
-		}
-	}(subVmStatus)
-	var vmResponse *types.VmResponse
-	for {
-		vmResponse = <-subVmStatus
-		glog.V(1).Infof("Get the response from VM, VM id is %s, response code is %d!", vmResponse.VmId, vmResponse.Code)
-		if vmResponse.VmId == vmId {
-			if vmResponse.Code == types.E_VM_RUNNING {
-				glog.Infof("Got E_VM_RUNNING code response")
-				break
-			} else {
-				break
-			}
-		}
-	}
-	if vmResponse.Code != types.E_VM_RUNNING {
-		return nil, fmt.Errorf("Vbox does not start successfully")
-	}
+
+	daemon.AddVm(vm)
 	return vm, nil
+}
+
+func (daemon *Daemon) WaitVmStart(vm *hypervisor.Vm) error {
+	_, r2, _, err1 := vm.GetVmChan()
+	if err1 != nil {
+		return err1
+	}
+	vmResponse := <-r2.(chan *types.VmResponse)
+	glog.V(1).Infof("Get the response from VM, VM id is %s, response code is %d!", vmResponse.VmId, vmResponse.Code)
+	if vmResponse.Code != types.E_VM_RUNNING {
+		return fmt.Errorf("Vbox does not start successfully")
+	}
+	return nil
+}
+
+func (daemon *Daemon) GetVM(vmId string, resource *pod.UserResource, lazy bool, keep int) (*hypervisor.Vm, error) {
+	if vmId == "" {
+		return daemon.StartVm("", resource.Vcpu, resource.Memory, lazy, keep)
+	}
+
+	vm, ok := daemon.VmList[vmId]
+	if !ok {
+		return nil, fmt.Errorf("The VM %s doesn't exist", vmId)
+	}
+	/* FIXME: check if any pod is running on this vm? */
+	glog.Infof("find vm:%s", vm.Id)
+	if resource.Vcpu != vm.Cpu {
+		return nil, fmt.Errorf("The new pod's cpu setting is different with the VM's cpu")
+	}
+
+	if resource.Memory != vm.Mem {
+		return nil, fmt.Errorf("The new pod's memory setting is different with the VM's memory")
+	}
+
+	return vm,nil
 }
 
 func (daemon *Daemon) NewVm(id string, cpu, memory int, lazy bool, keep int) *hypervisor.Vm {

--- a/daemon/vm.go
+++ b/daemon/vm.go
@@ -13,9 +13,9 @@ import (
 
 func (daemon *Daemon) CmdVmCreate(job *engine.Job) (err error) {
 	var (
-		vm   *hypervisor.Vm
-		cpu  = 1
-		mem  = 128
+		vm  *hypervisor.Vm
+		cpu = 1
+		mem = 128
 	)
 
 	if job.Args[0] != "" {
@@ -151,8 +151,12 @@ func (daemon *Daemon) StartVm(vmId string, cpu, mem int, lazy bool, keep int) (*
 		DEFAULT_MEM = 128
 	)
 
-	if cpu <= 0 { cpu = DEFAULT_CPU }
-	if mem <= 0 { mem = DEFAULT_MEM }
+	if cpu <= 0 {
+		cpu = DEFAULT_CPU
+	}
+	if mem <= 0 {
+		mem = DEFAULT_MEM
+	}
 
 	b := &hypervisor.BootConfig{
 		CPU:    cpu,
@@ -208,7 +212,7 @@ func (daemon *Daemon) GetVM(vmId string, resource *pod.UserResource, lazy bool, 
 		return nil, fmt.Errorf("The new pod's memory setting is different with the VM's memory")
 	}
 
-	return vm,nil
+	return vm, nil
 }
 
 func (daemon *Daemon) NewVm(id string, cpu, memory int, lazy bool, keep int) *hypervisor.Vm {

--- a/lib/docker/builder/internals.go
+++ b/lib/docker/builder/internals.go
@@ -307,7 +307,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 		b.Hyperdaemon.AddVm(vm)
 	}
 	if vm.Status == types.S_VM_IDLE {
-		code, cause, err := b.Hyperdaemon.StartPod(podId, "", b.Name, nil, false, false, types.VM_KEEP_AFTER_FINISH)
+		code, cause, err := b.Hyperdaemon.StartPod(podId, "", b.Name, nil, false, false, types.VM_KEEP_AFTER_FINISH, []*hypervisor.TtyIO{})
 		if err != nil {
 			glog.Errorf("Code is %d, Cause is %s, %s", code, cause, err.Error())
 			b.Hyperdaemon.KillVm(b.Name)
@@ -727,7 +727,7 @@ func (b *Builder) run(c *daemon.Container) error {
 		b.Hyperdaemon.AddVm(vm)
 	}
 	if vm.Status == types.S_VM_IDLE {
-		code, cause, err = b.Hyperdaemon.StartPod(podId, "", b.Name, nil, false, false, types.VM_KEEP_AFTER_FINISH)
+		code, cause, err = b.Hyperdaemon.StartPod(podId, "", b.Name, nil, false, false, types.VM_KEEP_AFTER_FINISH, []*hypervisor.TtyIO{})
 		if err != nil {
 			glog.Errorf("Code is %d, Cause is %s, %s", code, cause, err.Error())
 			b.Hyperdaemon.KillVm(b.Name)

--- a/lib/docker/daemon/graphdriver/vbox/driver.go
+++ b/lib/docker/daemon/graphdriver/vbox/driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperhq/hyper/daemon"
 	"github.com/hyperhq/hyper/lib/docker/daemon/graphdriver"
 	"github.com/hyperhq/hyper/utils"
+	"github.com/hyperhq/runv/hypervisor"
 	"github.com/hyperhq/runv/hypervisor/types"
 	"github.com/hyperhq/runv/lib/glog"
 	"github.com/hyperhq/runv/lib/govbox"
@@ -318,7 +319,7 @@ func (d *Driver) VmMountLayer(id string) error {
 		return fmt.Errorf("can not find VM(%s)", d.pullVm)
 	}
 	if vm.Status == types.S_VM_IDLE {
-		code, cause, err := d.daemon.StartPod(podId, podstring, d.pullVm, nil, false, true, types.VM_KEEP_AFTER_SHUTDOWN)
+		code, cause, err := d.daemon.StartPod(podId, podstring, d.pullVm, nil, false, true, types.VM_KEEP_AFTER_SHUTDOWN, []*hypervisor.TtyIO{})
 		if err != nil {
 			glog.Errorf("Code is %d, Cause is %s, %s", code, cause, err.Error())
 			d.daemon.KillVm(d.pullVm)

--- a/lib/docker/daemon/graphdriver/vbox/driver.go
+++ b/lib/docker/daemon/graphdriver/vbox/driver.go
@@ -102,11 +102,9 @@ func (d *Driver) Setup() error {
 		}
 		d.daemon = daemon
 	}
-	if vm, err := d.daemon.StartVm(d.pullVm, 1, 64, false, types.VM_KEEP_AFTER_SHUTDOWN); err != nil {
+	if _, err := d.daemon.StartVm(d.pullVm, 1, 64, false, types.VM_KEEP_AFTER_SHUTDOWN); err != nil {
 		glog.Errorf(err.Error())
 		return err
-	} else {
-		d.daemon.AddVm(vm)
 	}
 
 	if err := virtualbox.RegisterDisk(d.pullVm, d.pullVm, d.BaseImage(), 4); err != nil {

--- a/lib/docker/daemon/graphdriver/vbox/fsdiff.go
+++ b/lib/docker/daemon/graphdriver/vbox/fsdiff.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperhq/hyper/lib/docker/pkg/chrootarchive"
 	"github.com/hyperhq/hyper/lib/docker/pkg/ioutils"
 	"github.com/hyperhq/hyper/utils"
+	"github.com/hyperhq/runv/hypervisor"
 	"github.com/hyperhq/runv/hypervisor/types"
 	"github.com/hyperhq/runv/lib/glog"
 	"github.com/hyperhq/runv/lib/govbox"
@@ -80,7 +81,7 @@ func (d *Driver) Diff(id, parent string) (diff archive.Archive, err error) {
 		return nil, fmt.Errorf("can not find VM(%s)", d.pullVm)
 	}
 	if vm.Status == types.S_VM_IDLE {
-		code, cause, err = d.daemon.StartPod(podId, podData, d.pullVm, nil, false, true, types.VM_KEEP_AFTER_SHUTDOWN)
+		code, cause, err = d.daemon.StartPod(podId, podData, d.pullVm, nil, false, true, types.VM_KEEP_AFTER_SHUTDOWN, []*hypervisor.TtyIO{})
 		if err != nil {
 			glog.Errorf("Code is %d, Cause is %s, %s", code, cause, err.Error())
 			d.daemon.KillVm(d.pullVm)


### PR DESCRIPTION
originally we start pod, then attach tty to it. Then we may miss
the beginning of the tty output. Even miss all the output if the
progress exit at once.

this patch include the hyper part and runv part, to enable
establishing the tty connection before starting pod. The result
will be like:

    gnawux@sonic$ ./hyper run busybox ps aux
    PID   USER     COMMAND
        1 root     /init
        2 root     ps aux
    Successfully attached to pod(pod-xhZAmXwXCV)
    End of CmdExec(), Waiting for hijack to finish.
    POD id is pod-xhZAmXwXCV

Signed-off-by: Wang Xu <gnawux@gmail.com>