### PR TITLE
Improve list functionality

### DIFF
--- a/client/list.go
+++ b/client/list.go
@@ -12,8 +12,13 @@ import (
 )
 
 func (cli *HyperClient) HyperCmdList(args ...string) error {
-	var parser = gflag.NewParser(nil, gflag.Default)
-	parser.Usage = "list [pod|container]\n\nlist all pods or container information"
+	var opts struct {
+		Aux bool   `short:"x" long:"aux" default:"false" value-name:"false" description:"show the auxiliary containers"`
+		Pod string `short:"p" long:"pod" value-name:"\"\"" description:"only list the specified pod"`
+	}
+
+	var parser = gflag.NewParser(&opts, gflag.Default|gflag.IgnoreUnknown)
+	parser.Usage = "list [OPTIONS] [pod|container]\n\nlist all pods or container information"
 	args, err := parser.Parse()
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
@@ -35,6 +40,12 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 
 	v := url.Values{}
 	v.Set("item", item)
+	if opts.Aux {
+		v.Set("auxiliary", "yes")
+	}
+	if opts.Pod != "" {
+		v.Set("pod", opts.Pod)
+	}
 	body, _, err := readBody(cli.call("GET", "/list?"+v.Encode(), nil, nil))
 	if err != nil {
 		return err

--- a/client/run.go
+++ b/client/run.go
@@ -246,6 +246,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) error {
 func (cli *HyperClient) GetContainerByPod(podId string) (string, error) {
 	v := url.Values{}
 	v.Set("item", "container")
+	v.Set("pod", podId)
 	body, _, err := readBody(cli.call("GET", "/list?"+v.Encode(), nil, nil))
 	if err != nil {
 		return "", err

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -44,7 +44,7 @@ func (daemon *Daemon) CmdExec(job *engine.Job) (err error) {
 
 	vm, ok := daemon.VmList[vmId]
 	if !ok {
-		return fmt.Errorf("Can find VM whose Id is %s!", vmId)
+		return fmt.Errorf("Can not find VM whose Id is %s!", vmId)
 	}
 
 	err = vm.Exec(job.Stdin, job.Stdout, cmd, tag, container)

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -2,13 +2,24 @@ package daemon
 
 import (
 	"fmt"
+
 	"github.com/hyperhq/hyper/engine"
+	"github.com/hyperhq/runv/hypervisor"
 	"github.com/hyperhq/runv/hypervisor/types"
 	"github.com/hyperhq/runv/lib/glog"
 )
 
 func (daemon *Daemon) CmdList(job *engine.Job) error {
-	var item string
+	var (
+		item                  string
+		dedicade              bool            = false
+		podId                 string          = ""
+		auxiliary             bool            = false
+		pod                   *hypervisor.Pod = nil
+		vmJsonResponse                        = []string{}
+		podJsonResponse                       = []string{}
+		containerJsonResponse                 = []string{}
+	)
 	if len(job.Args) == 0 {
 		item = "pod"
 	} else {
@@ -18,93 +29,62 @@ func (daemon *Daemon) CmdList(job *engine.Job) error {
 		return fmt.Errorf("Can not support %s list!", item)
 	}
 
-	var (
-		vmJsonResponse        = []string{}
-		podJsonResponse       = []string{}
-		containerJsonResponse = []string{}
-		status                string
-		podId                 string
-	)
+	if len(job.Args) > 1 && (job.Args[1] != "") {
+		dedicade = true
+		podId = job.Args[1]
+	}
+
+	if len(job.Args) > 2 && (job.Args[2] == "yes" || job.Args[2] == "true") {
+		auxiliary = true
+	}
 
 	daemon.PodsMutex.RLock()
 	glog.Infof("lock read of PodList")
 	defer glog.Infof("unlock read of PodList")
 	defer daemon.PodsMutex.RUnlock()
+
+	if dedicade {
+		var ok bool
+		pod, ok = daemon.PodList[podId]
+		if !ok || (pod == nil) {
+			return fmt.Errorf("Cannot find specified pod %s", podId)
+		}
+	}
+
 	// Prepare the VM status to client
 	v := &engine.Env{}
 	v.Set("item", item)
 	if item == "vm" {
-		for vm, v := range daemon.VmList {
-			switch v.Status {
-			case types.S_VM_ASSOCIATED:
-				status = "associated"
-				break
-			case types.S_VM_IDLE:
-				status = "idle"
-				break
-			default:
-				status = ""
-				break
+		if !dedicade {
+			for vm, v := range daemon.VmList {
+				vmJsonResponse = append(vmJsonResponse, vm+":"+showVM(v))
 			}
-			if v.Pod != nil {
-				podId = v.Pod.Id
+		} else {
+			if v, ok := daemon.VmList[pod.Vm]; ok {
+				vmJsonResponse = append(vmJsonResponse, pod.Vm+":"+showVM(v))
 			}
-			vmJsonResponse = append(vmJsonResponse, vm+":"+podId+":"+status)
 		}
 		v.SetList("vmData", vmJsonResponse)
 	}
 
 	if item == "pod" {
-		for p, v := range daemon.PodList {
-			switch v.Status {
-			case types.S_POD_RUNNING:
-				status = "running"
-				break
-			case types.S_POD_CREATED:
-				status = "pending"
-				break
-			case types.S_POD_FAILED:
-				status = "failed"
-				if v.Type == "kubernetes" {
-					status = "failed(kubernetes)"
-				}
-				break
-			case types.S_POD_SUCCEEDED:
-				status = "succeeded"
-				if v.Type == "kubernetes" {
-					status = "succeeded(kubernetes)"
-				}
-				break
-			default:
-				status = ""
-				break
+		if !dedicade {
+			for p, v := range daemon.PodList {
+				podJsonResponse = append(podJsonResponse, p+":"+showPod(v))
 			}
-			podJsonResponse = append(podJsonResponse, p+":"+v.Name+":"+v.Vm+":"+status)
+		} else {
+			podJsonResponse = append(podJsonResponse, pod.Id+":"+showPod(pod))
 		}
 		v.SetList("podData", podJsonResponse)
 	}
 
 	if item == "container" {
-		for _, p := range daemon.PodList {
-			for _, c := range p.Containers {
-				switch c.Status {
-				case types.S_POD_RUNNING:
-					status = "running"
-					break
-				case types.S_POD_CREATED:
-					status = "pending"
-					break
-				case types.S_POD_FAILED:
-					status = "failed"
-					break
-				case types.S_POD_SUCCEEDED:
-					status = "succeeded"
-					break
-				default:
-					status = ""
-				}
-				containerJsonResponse = append(containerJsonResponse, c.Id+":"+c.Name+":"+c.PodId+":"+status)
+		if !dedicade {
+			for _, p := range daemon.PodList {
+				containerJsonResponse = append(containerJsonResponse, showPodContainers(p, auxiliary)...)
 			}
+		} else {
+			containerJsonResponse = append(containerJsonResponse, showPodContainers(pod, auxiliary)...)
 		}
 		v.SetList("cData", containerJsonResponse)
 	}
@@ -114,4 +94,84 @@ func (daemon *Daemon) CmdList(job *engine.Job) error {
 	}
 
 	return nil
+}
+
+func showVM(v *hypervisor.Vm) string {
+	var status string
+	switch v.Status {
+	case types.S_VM_ASSOCIATED:
+		status = "associated"
+		break
+	case types.S_VM_IDLE:
+		status = "idle"
+		break
+	default:
+		status = ""
+		break
+	}
+	p := ""
+	if v.Pod != nil {
+		p = v.Pod.Id
+	}
+
+	return p + ":" + status
+}
+
+func showPod(pod *hypervisor.Pod) string {
+	var status string
+
+	switch pod.Status {
+	case types.S_POD_RUNNING:
+		status = "running"
+	case types.S_POD_CREATED:
+		status = "pending"
+	case types.S_POD_FAILED:
+		status = "failed"
+		if pod.Type == "kubernetes" {
+			status = "failed(kubernetes)"
+		}
+	case types.S_POD_SUCCEEDED:
+		status = "succeeded"
+		if pod.Type == "kubernetes" {
+			status = "succeeded(kubernetes)"
+		}
+	default:
+		status = ""
+	}
+
+	return pod.Name + ":" + pod.Vm + ":" + status
+}
+
+func showPodContainers(pod *hypervisor.Pod, aux bool) []string {
+
+	rsp := []string{}
+	filterServiceDiscovery := !aux && (pod.Type == "service-discovery")
+	proxyName := ServiceDiscoveryContainerName(pod.Name)
+
+	for _, c := range pod.Containers {
+		if filterServiceDiscovery && c.Name == proxyName {
+			continue
+		}
+		rsp = append(rsp, showContainer(c))
+	}
+	return rsp
+}
+
+func showContainer(c *hypervisor.Container) string {
+	var status string
+
+	switch c.Status {
+	case types.S_POD_RUNNING:
+		status = "running"
+	case types.S_POD_CREATED:
+		status = "pending"
+	case types.S_POD_FAILED:
+		status = "failed"
+	case types.S_POD_SUCCEEDED:
+		status = "succeeded"
+	default:
+		status = ""
+	}
+
+	return c.Id + ":" + c.Name + ":" + c.PodId + ":" + status
 }

--- a/daemon/servicediscovery.go
+++ b/daemon/servicediscovery.go
@@ -170,7 +170,7 @@ func (daemon *Daemon) ProcessPodBytes(body []byte, podId string) (*pod.UserPod, 
 
 	userPod.Type = "service-discovery"
 	serviceContainer := pod.UserContainer{
-		Name:    userPod.Name + "-service-discovery",
+		Name:    ServiceDiscoveryContainerName(userPod.Name),
 		Image:   servicediscovery.ServiceImage,
 		Command: []string{"haproxy", "-D", "-f", "/usr/local/etc/haproxy/haproxy.cfg", "-p", "/var/run/haproxy.pid"},
 	}
@@ -201,4 +201,8 @@ func (daemon *Daemon) ProcessPodBytes(body []byte, podId string) (*pod.UserPod, 
 	userPod.Containers = containers
 
 	return userPod, nil
+}
+
+func ServiceDiscoveryContainerName(podName string) string {
+	return podName + "-service-discovery"
 }

--- a/server/server.go
+++ b/server/server.go
@@ -183,8 +183,13 @@ func getList(eng *engine.Engine, version version.Version, w http.ResponseWriter,
 		return nil
 	}
 
-	glog.V(1).Infof("List type is %s", r.Form.Get("item"))
-	job := eng.Job("list", r.Form.Get("item"))
+	item := r.Form.Get("item")
+	auxiliary := r.Form.Get("auxiliary")
+	pod := r.Form.Get("pod")
+
+	glog.V(1).Infof("List type is %s, specified pod: [%s], list auxiliary pod: %s", item, pod, auxiliary)
+	job := eng.Job("list", item, pod, auxiliary)
+
 	stdoutBuf := bytes.NewBuffer(nil)
 
 	job.Stdout.Add(stdoutBuf)


### PR DESCRIPTION
- do not show the auxiliary containers by default, only show if with `-x` option or
  `auxiliary=yes` exist in request URL parameter
- add `-p` option or `pod={pod_id}` in request URL parameter to list only the specified
  pod, rather than list all.

with this patch, exec {pod-id} will not exec to the service discovery auxiliary container