### PR TITLE
the file insert is rewritten, finish all the functions by design

### DIFF
--- a/examples/insert-file.pod
+++ b/examples/insert-file.pod
@@ -1,0 +1,59 @@
+{
+	"id": "test-inject-file",
+	"containers" : [{
+	    "name": "file-tester",
+	    "image": "ubuntu:latest",
+	    "workdir": "/",
+	    "command": ["/bin/bash"],
+		"files": [{
+			"path": "/root/test/",
+			"filename": "resolv.conf",
+			"perm": "0600"
+		},{
+			"path": "/root/test/logo.png",
+			"filename": "logo",
+			"perm": "0644",
+			"user": "1000",
+			"group": "1000"
+		},{
+			"path": "/root/test/t1",
+			"filename": "data",
+			"perm": "0644"
+		},{
+			"path": "/root/test/t2",
+			"filename": "data2",
+			"perm": "0755"
+		},{
+			"path": "/root/test/t3",
+			"filename": "corrupt",
+			"perm": "0000"
+		}]
+	}],
+	"resource": {
+	    "vcpu": 1,
+	    "memory": 512
+	},
+	"files": [{
+		"name": "resolv.conf",
+		"encoding": "raw",
+		"uri": "file:///etc/resolv.conf"
+	},{
+		"name": "logo",
+		"encoding": "raw",
+		"uri": "http://7xj84t.com1.z0.glb.clouddn.com/test/logo.png"
+	},{
+		"name": "data",
+		"encoding": "raw",
+		"content": ""
+	},{
+		"name": "data2",
+		"encoding": "base64",
+		"content": "aGVsbG8sDQpoeXBlciENCg=="
+	},{
+		"name": "corrupt",
+		"encoding": "base64",
+		"content": "VsbG8sDQpoeXBlciENCg="
+	}],
+	"volumes": [],
+	"tty": true
+}

--- a/storage/aufs/aufs.go
+++ b/storage/aufs/aufs.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
-	"strconv"
 	"sync"
 	"syscall"
 
@@ -61,50 +59,6 @@ func MountContainerToSharedDir(containerId, rootDir, sharedDir, mountLabel strin
 	}
 
 	return mountPoint, nil
-}
-
-func AttachFiles(containerId, fromFile, toDir, rootDir, perm, uid, gid string) error {
-	if containerId == "" {
-		return fmt.Errorf("Please make sure the arguments are not NULL!\n")
-	}
-	permInt := utils.ConvertPermStrToInt(perm)
-	// It just need the block device without copying any files
-	// FIXME whether we need to return an error if the target directory is null
-	if toDir == "" {
-		return nil
-	}
-	// Make a new file with the given premission and wirte the source file content in it
-	if _, err := os.Stat(fromFile); err != nil && os.IsNotExist(err) {
-		return err
-	}
-	buf, err := ioutil.ReadFile(fromFile)
-	if err != nil {
-		return err
-	}
-	targetDir := path.Join(rootDir, containerId, "rootfs", toDir)
-	_, err = os.Stat(targetDir)
-	targetFile := targetDir
-	if err != nil && os.IsNotExist(err) {
-		// we need to create a target directory with given premission
-		if err := os.MkdirAll(targetDir, os.FileMode(permInt)); err != nil {
-			return err
-		}
-		targetFile = targetDir + "/" + filepath.Base(fromFile)
-	} else {
-		targetFile = targetDir + "/" + filepath.Base(fromFile)
-	}
-	err = ioutil.WriteFile(targetFile, buf, os.FileMode(permInt))
-	if err != nil {
-		return err
-	}
-
-	user_id, _ := strconv.Atoi(uid)
-	group_id, _ := strconv.Atoi(gid)
-	if err = syscall.Chown(targetFile, user_id, group_id); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func getParentDiffPaths(id, rootPath string) ([]string, error) {

--- a/storage/files.go
+++ b/storage/files.go
@@ -1,0 +1,59 @@
+// +build linux
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"syscall"
+)
+
+func FsInjectFile(src io.Reader, containerId, target, rootDir string, perm, uid, gid int) error {
+	if containerId == "" {
+		return fmt.Errorf("Please make sure the arguments are not NULL!\n")
+	}
+
+	targetFile := path.Join(rootDir, containerId, "rootfs", target)
+
+	return WriteFile(src, targetFile, perm, uid, gid)
+
+}
+
+func WriteFile(src io.Reader, targetFile string, permFile, uid, gid int) error {
+
+	targetDir := filepath.Dir(targetFile)
+	permDir := permFile | 0111
+
+	if stat, err := os.Stat(targetDir); err != nil {
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(targetDir, os.FileMode(permDir))
+		}
+		if err != nil {
+			return err
+		}
+	} else if !stat.IsDir() {
+		return errors.New("File target is not a dir: " + targetDir)
+	}
+
+	f, err := os.OpenFile(targetFile, os.O_RDWR|os.O_CREATE, os.FileMode(permFile))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, src)
+	if err != nil {
+		return err
+	}
+
+	if err = syscall.Chown(targetFile, uid, gid); err != nil {
+		return err
+	}
+
+	return nil
+
+}


### PR DESCRIPTION
including:

- path could include the filename, then not use the name list in pod/files/?/name
- user/group could be "root" or id, not those in host system
- uri support http/https and file:
- content could be empty

and the new implementation avoid writing multiple tmp files.

example pod:

```
{
	"id": "test-inject-file",
	"containers" : [{
	    "name": "file-tester",
	    "image": "ubuntu:latest",
	    "workdir": "/",
	    "command": ["/bin/bash"],
		"files": [{
			"path": "/root/test/",
			"filename": "resolv.conf",
			"perm": "0600"
		},{
			"path": "/root/test/logo.png",
			"filename": "logo",
			"perm": "0644",
			"user": "1000",
			"group": "1000"
		},{
			"path": "/root/test/t1",
			"filename": "data",
			"perm": "0644"
		},{
			"path": "/root/test/t2",
			"filename": "data2",
			"perm": "0755"
		},{
			"path": "/root/test/t3",
			"filename": "corrupt",
			"perm": "0000"
		}]
	}],
	"resource": {
	    "vcpu": 1,
	    "memory": 512
	},
	"files": [{
		"name": "resolv.conf",
		"encoding": "raw",
		"uri": "file:///etc/resolv.conf"
	},{
		"name": "logo",
		"encoding": "raw",
		"uri": "http://7xj84t.com1.z0.glb.clouddn.com/test/logo.png"
	},{
		"name": "data",
		"encoding": "raw",
		"content": ""
	},{
		"name": "data2",
		"encoding": "base64",
		"content": "aGVsbG8sDQpoeXBlciENCg=="
	},{
		"name": "corrupt",
		"encoding": "base64",
		"content": "VsbG8sDQpoeXBlciENCg="
	}],
	"volumes": [],
	"tty": true
}
```

Signed-off-by: Wang Xu <gnawux@gmail.com>