### PR TITLE
put the pod string into data area of request

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -118,8 +118,7 @@
 		},
 		{
 			"ImportPath": "github.com/tchap/go-patricia/patricia",
-			"Comment": "v2.2.0-3-gdf2b712",
-			"Rev": "df2b712478cafdbfe2d6107b809c8ba9cf67c6d9"
+			"Rev": "42daf53d2c20234572a4640ac642df046505562d"
 		},
 		{
 			"ImportPath": "gopkg.in/fsnotify.v1",

--- a/Godeps/_workspace/src/github.com/tchap/go-patricia/patricia/children.go
+++ b/Godeps/_workspace/src/github.com/tchap/go-patricia/patricia/children.go
@@ -79,7 +79,9 @@ func (list *sparseChildList) replace(b byte, child *Trie) {
 func (list *sparseChildList) remove(child *Trie) {
 	for i, node := range list.children {
 		if node.prefix[0] == child.prefix[0] {
-			list.children = append(list.children[:i], list.children[i+1:]...)
+			list.children, list.children[len(list.children)-1] =
+				append(list.children[:i], list.children[i+1:]...),
+				nil
 			return
 		}
 	}

--- a/Godeps/_workspace/src/github.com/tchap/go-patricia/patricia/patricia.go
+++ b/Godeps/_workspace/src/github.com/tchap/go-patricia/patricia/patricia.go
@@ -263,7 +263,12 @@ func (trie *Trie) Delete(key Prefix) (deleted bool) {
 
 	// Remove the node if it has no items.
 	if node.empty() {
-		parent.children.remove(node)
+		// If at the root of the trie, reset
+		if parent == nil {
+			node.reset()
+		} else {
+			parent.children.remove(node)
+		}
 	}
 
 	return true
@@ -291,8 +296,7 @@ func (trie *Trie) DeleteSubtree(prefix Prefix) (deleted bool) {
 
 	// If we are in the root of the trie, reset the trie.
 	if parent == nil {
-		root.prefix = nil
-		root.children = newSparseChildList(trie.maxPrefixPerNode)
+		root.reset()
 		return true
 	}
 
@@ -312,6 +316,11 @@ func (trie *Trie) empty() bool {
 	})
 
 	return isEmpty
+}
+
+func (trie *Trie) reset() {
+	trie.prefix = nil
+	trie.children = newSparseChildList(trie.maxPrefixPerNode)
 }
 
 func (trie *Trie) put(key Prefix, item Item, replace bool) (inserted bool) {

--- a/Godeps/_workspace/src/github.com/tchap/go-patricia/patricia/patricia_test.go
+++ b/Godeps/_workspace/src/github.com/tchap/go-patricia/patricia/patricia_test.go
@@ -90,3 +90,21 @@ func TestTrie_RandomKitchenSink(t *testing.T) {
 		getAndDelete(k, v)
 	}
 }
+
+// Make sure Delete that affects the root node works.
+// This was panicking when Delete was broken.
+func TestTrie_DeleteRoot(t *testing.T) {
+	trie := NewTrie()
+
+	v := testData{"aba", 0, success}
+
+	t.Logf("INSERT prefix=%v, item=%v, success=%v", v.key, v.value, v.retVal)
+	if ok := trie.Insert(Prefix(v.key), v.value); ok != v.retVal {
+		t.Errorf("Unexpected return value, expected=%v, got=%v", v.retVal, ok)
+	}
+
+	t.Logf("DELETE prefix=%v, item=%v, success=%v", v.key, v.value, v.retVal)
+	if ok := trie.Delete(Prefix(v.key)); ok != v.retVal {
+		t.Errorf("Unexpected return value, expected=%v, got=%v", v.retVal, ok)
+	}
+}

--- a/client/kill.go
+++ b/client/kill.go
@@ -29,7 +29,7 @@ func (cli *HyperClient) HyperCmdKill(args ...string) error {
 	vmId := args[1]
 	v := url.Values{}
 	v.Set("vm", vmId)
-	body, _, err := readBody(cli.call("POST", "/vm/kill?"+v.Encode(), nil, nil))
+	body, _, err := readBody(cli.call("DELETE", "/vm?"+v.Encode(), nil, nil))
 	if err != nil {
 		return err
 	}

--- a/client/rm.go
+++ b/client/rm.go
@@ -40,7 +40,7 @@ func (cli *HyperClient) HyperCmdRm(args ...string) error {
 func (cli *HyperClient) RmPod(id string) error {
 	v := url.Values{}
 	v.Set("podId", id)
-	body, _, err := readBody(cli.call("POST", "/pod/remove?"+v.Encode(), nil, nil))
+	body, _, err := readBody(cli.call("DELETE", "/pod?"+v.Encode(), nil, nil))
 	if err != nil {
 		return fmt.Errorf("Error to remove pod(%s), %s", id, err.Error())
 	}

--- a/client/rmi.go
+++ b/client/rmi.go
@@ -45,7 +45,7 @@ func (cli *HyperClient) HyperCmdRmi(args ...string) error {
 		v.Set("imageId", imageId)
 		v.Set("noprune", noprune)
 		v.Set("force", force)
-		body, _, err := readBody(cli.call("POST", "/images/remove?"+v.Encode(), nil, nil))
+		body, _, err := readBody(cli.call("DELETE", "/image?"+v.Encode(), nil, nil))
 		if err != nil {
 			fmt.Fprintf(cli.err, "Error remove the image(%s): %s\n", imageId, err.Error())
 			continue

--- a/client/utils.go
+++ b/client/utils.go
@@ -50,7 +50,7 @@ func (cli *HyperClient) encodeData(data interface{}) (*bytes.Buffer, error) {
 }
 
 func (cli *HyperClient) clientRequest(method, path string, in io.Reader, headers map[string][]string) (io.ReadCloser, string, int, error) {
-	expectedPayload := (method == "POST" || method == "PUT")
+	expectedPayload := (method == "POST" || method == "PUT" || method == "DELETE")
 	if expectedPayload && in == nil {
 		in = bytes.NewReader([]byte{})
 	}


### PR DESCRIPTION
* put the pod string into data area of request
* make the resource(service, pod, vm and image) 's delete operation as `DELETE` method

This fix makes the request url clean without pod data, put the pod data string into data area of the request.  And adding `DELETE` operation for resource(such as service, pod, vm and image) 's delete operation.

#### API change list
* kill vm
    * old
     `POST /vm/kill?vmId=vm-xxxx`
    * new
     `DELETE /vm?vmId=vm-xxxx`
* remove service
    * old
     `POST /service/delete"?podId=pod-xxxx&service=xxx`
    * new
     `DELETE /service?podId=pod-xxxx&service=xxx`
* remove pod
    * old
     `POST /pod/remove?podId=pod-xxxx`
    * new
     `DELETE /pod?podId=pod-xxxx`
* remove image
    * old
     `POST /images/remove?imageId=xxxx`
    * new
     `DELETE /image?imageId=xxxx`
* create pod
     * old
`POST /pod/create?podArgs={"id":"xxx", "containers":.....}`
     * new
`POST /pod/create`
put the pod data string into request, and set `Content-Type` to `application/json`.
* run pod
     * old
`POST /pod/run?podArgs={"id":"xxx", "containers":.....}`
     * new
`POST /pod/run`
put the pod data string into request, and set `Content-Type` to `application/json`.


######  PS. This patch will impact the [hypernetes](https://github.com/hyperhq/hypernetes) 

#### Test Result
```
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper images
REPOSITORY     TAG                 IMAGE ID                           CREATED             VIRTUAL SIZE
busybox        latest              3d5bcd78e074                2015-10-21 05:56:30              1.1 MB
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper rmi busybox
Image(busybox) is successful to be deleted!
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper pull busybox
latest: Pulling from busybox
bf0f46991aed: Pull complete
3d5bcd78e074: Pull complete
busybox:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
Digest: sha256:5551dbdfc48d66734d0f01cafee0952cb6e8eeecd1e2492240bf2fd9640c2279
Status: Downloaded newer image for busybox:latest
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# curl -X POST http://127.0.0.1:12345/pod/create -d "$(cat examples/ubuntu.pod)" -H "Content-Type: application/json"
{"Cause":"","Code":0,"ID":"pod-QALerbrTch"}
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# vim examples/ubuntu.pod
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# curl -X POST http://127.0.0.1:12345/pod/create -d "$(cat examples/ubuntu.pod)" -H "Content-Type: application/json"
{"Cause":"","Code":0,"ID":"pod-qUPYFiXNzt"}
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper list
         POD ID                      POD Name             VM name    Status
 pod-QALerbrTch   test-container-create-busyb                       pending
 pod-qUPYFiXNzt   test-container-create-busyb                       pending
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# curl -X DELETE http://127.0.0.1:12345/pod?podId=pod-QALerbrTch
{"Cause":"","Code":0,"ID":"pod-QALerbrTch"}
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# curl -X DELETE http://127.0.0.1:12345/pod?podId=pod-qUPYFiXNzt
{"Cause":"","Code":0,"ID":"pod-qUPYFiXNzt"}
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper list
         POD ID                      POD Name             VM name    Status
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper images
REPOSITORY     TAG                 IMAGE ID                           CREATED             VIRTUAL SIZE
busybox        latest              3d5bcd78e074                2015-10-21 05:56:30              1.1 MB
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper#
```