### PR TITLE
format the output of 'images' and 'list'

### DIFF
--- a/client/images.go
+++ b/client/images.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/hyperhq/hyper/engine"
@@ -58,19 +59,21 @@ func (cli *HyperClient) HyperCmdImages(args ...string) error {
 	)
 	imagesList = remoteInfo.GetList("imagesList")
 
+	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if opts.Num == false {
-		fmt.Printf("%-15s%-20s%-22s%20s     %20s\n", "REPOSITORY", "TAG", "IMAGE ID", "CREATED", "VIRTUAL SIZE")
+		fmt.Fprintln(w, "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tVIRTUAL SIZE")
 		for _, item := range imagesList {
 			fields := strings.Split(item, ":")
 			date, _ := strconv.ParseUint(fields[3], 0, 64)
-			fmt.Printf("%-15s%-20s%-22s%25s%20s\n", fields[0], fields[1], fields[2][:12], time.Unix(int64(date), 0).Format("2006-01-02 15:04:05"), getImageSizeString(fields[4]))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", fields[0], fields[1], fields[2][:12], time.Unix(int64(date), 0).Format("2006-01-02 15:04:05"), getImageSizeString(fields[4]))
 		}
 	} else {
 		for _, item := range imagesList {
 			fields := strings.Split(item, ":")
-			fmt.Printf("%s\n", fields[2][:12])
+			fmt.Fprintf(w, "%s\n", fields[2][:12])
 		}
 	}
+	w.Flush()
 
 	return nil
 }

--- a/client/list.go
+++ b/client/list.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/hyperhq/hyper/engine"
 
@@ -74,6 +75,7 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 		return fmt.Errorf("Found an error while getting %s list: %s", item, remoteInfo.Get("Error"))
 	}
 
+	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if item == "vm" {
 		vmResponse = remoteInfo.GetList("vmData")
 	}
@@ -86,27 +88,23 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 
 	//fmt.Printf("Item is %s\n", item)
 	if item == "vm" {
-		fmt.Printf("%15s%20s\n", "VM name", "Status")
+		fmt.Fprintln(w, "VM name\tStatus")
 		for _, vm := range vmResponse {
 			fields := strings.Split(vm, ":")
-			fmt.Printf("%15s%20s\n", fields[0], fields[2])
+			fmt.Fprintf(w, "%s\t%s\n", fields[0], fields[2])
 		}
 	}
 
 	if item == "pod" {
-		fmt.Printf("%15s%30s%20s%10s\n", "POD ID", "POD Name", "VM name", "Status")
+		fmt.Fprintln(w, "POD ID\tPOD Name\tVM name\tStatus")
 		for _, p := range podResponse {
 			fields := strings.Split(p, ":")
-			var podName = fields[1]
-			if len(fields[1]) > 27 {
-				podName = fields[1][:27]
-			}
-			fmt.Printf("%15s%30s%20s%10s\n", fields[0], podName, fields[2], fields[3])
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", fields[0], fields[1], fields[2], fields[3])
 		}
 	}
 
 	if item == "container" {
-		fmt.Printf("%-66s%-20s%15s%10s\n", "Container ID", "Name", "POD ID", "Status")
+		fmt.Fprintln(w, "Container ID\tName\tPOD ID\tStatus")
 		for _, c := range containerResponse {
 			fields := strings.Split(c, ":")
 			name := fields[1]
@@ -115,8 +113,9 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 					name = name[1:]
 				}
 			}
-			fmt.Printf("%-66s%-20s%15s%10s\n", fields[0], name, fields[2], fields[3])
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", fields[0], name, fields[2], fields[3])
 		}
 	}
+	w.Flush()
 	return nil
 }


### PR DESCRIPTION
make the client output be flexible

```
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper list pod
POD ID              POD Name                        VM name             Status
pod-NnnmWrAMhX      seaweedfs-1117462063                                failed
pod-nGOpkBxhtm      test-container-create-busybox                       pending
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper rm pod-nGOpkBxhtm
Pod(pod-nGOpkBxhtm) is successful to be deleted!
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper list pod
POD ID              POD Name               VM name             Status
pod-NnnmWrAMhX      seaweedfs-1117462063                       failed
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper create test.pod
Pod ID is pod-NZosdJusbg
root@ubuntu:/home/lei/src/github.com/hyperhq/hyper# ./hyper list pod
POD ID              POD Name                                  VM name             Status
pod-NnnmWrAMhX      seaweedfs-1117462063                                          failed
pod-NZosdJusbg      test-test-test-container-create-busybox                       pending
```