### PR TITLE
add registry mirror and insecure registry options for hyperd

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -36,7 +36,7 @@ type Docker struct {
 	daemon *daemon.Daemon
 }
 
-func Init() {
+func Init(mirrors []string, insecureRegistries []string) {
 	if daemonCfg.LogConfig.Config == nil {
 		daemonCfg.LogConfig.Config = make(map[string]string)
 	}
@@ -44,6 +44,12 @@ func Init() {
 	flags := flag.NewFlagSet("", errhandler)
 	daemonCfg.InstallFlags(flags, presentInHelp)
 	registryCfg.InstallFlags(flags, absentFromHelp)
+	for _, m := range mirrors {
+		registryCfg.Mirrors.Set(m)
+	}
+	for _, ir := range insecureRegistries {
+		registryCfg.InsecureRegistries.Set(ir)
+	}
 	hyperd.NewDockerImpl = func() (docker hyperd.DockerInterface, e error) {
 		docker, e = NewDocker()
 		if e != nil {


### PR DESCRIPTION
new options for `hyperd`

```
# ./hyperd --help
Usage:
  ./hyperd [OPTIONS]

Application Options:
  --nondaemon            Not daemonize
  --config=""            Configuration for ./hyperd
  --v=0                  Log level fro V logs
  --log_dir              Log directory
  --host                 Host address and port for hyperd(such as --host=tcp://127.0.0.1:12345)
  --registry_mirror      Prefered docker registry mirror, multiple values separated by a comma
  --insecure_registry    Enable insecure registry communication, multiple values separated by a comma
  --logtostderr          Log to standard error instead of files
  --alsologtostderr      Log to standard error as well as files

Help Options:
  -h, --help             Show this help message

```