### PR TITLE
Add cpu/memory to pod info api

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -178,6 +178,8 @@ func (daemon *Daemon) CmdPodInfo(job *engine.Job) error {
 		Volumes:    podVoumes,
 		Containers: containers,
 		Labels:     pod.spec.Labels,
+		Vcpu:       pod.spec.Resource.Vcpu,
+		Memory:     pod.spec.Resource.Memory,
 	}
 	podIPs := []string{}
 	if pod.vm != nil {

--- a/types/pod.go
+++ b/types/pod.go
@@ -36,6 +36,8 @@ type PodSpec struct {
 	Volumes    []PodVolume       `json:"volumes"`
 	Containers []Container       `json:"containers"`
 	Labels     map[string]string `json:"labels"`
+	Vcpu       int               `json:"vcpu"`
+	Memory     int               `json:"memory"`
 }
 
 type PodStatus struct {


### PR DESCRIPTION
Add cpu/memory to pod info api, so we can check cpu and memory info of pod spec.

```sh
[root@host ~]# curl -s 'hyper-api/pod/info?podName=pod-pNBQIpaHzp'  | jq .spec.memory
128
[root@host ~]# curl -s 'hyper-api/pod/info?podName=pod-pNBQIpaHzp'  | jq .spec.vcpu
1
```