### PR TITLE
use the 1.4 version of haproxy image

### DIFF
--- a/servicediscovery/servicediscovery.go
+++ b/servicediscovery/servicediscovery.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	ServiceVolume string = "/usr/local/etc/haproxy/"
-	ServiceImage  string = "haproxy:latest"
+	ServiceImage  string = "haproxy:1.4"
 	ServiceConfig string = "haproxy.cfg"
 )
 


### PR DESCRIPTION
the haproxy configuration of new haproxy image is changed, only
support 1.4 version of haproxy image now.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>