### PR TITLE
prefetching workflow

### DIFF
--- a/client/create.go
+++ b/client/create.go
@@ -31,7 +31,7 @@ func (cli *HyperClient) HyperCmdCreate(args ...string) error {
 		return err
 	}
 
-	podId, err := cli.CreatePod(jsonbody, false)
+	podId, err := cli.CreatePod(jsonbody, false, false)
 	if err != nil {
 		return err
 	}

--- a/client/pod.go
+++ b/client/pod.go
@@ -52,10 +52,13 @@ func (cli *HyperClient) HyperCmdPod(args ...string) error {
 	return nil
 }
 
-func (cli *HyperClient) CreatePod(jsonbody string, remove bool) (string, error) {
+func (cli *HyperClient) CreatePod(jsonbody string, remove, prefetchVm bool) (string, error) {
 	v := url.Values{}
 	if remove {
 		v.Set("remove", "yes")
+	}
+	if prefetchVm {
+		v.Set("prefetchvm", "yes")
 	}
 	var tmpPod pod.UserPod
 	if err := json.Unmarshal([]byte(jsonbody), &tmpPod); err != nil {

--- a/client/replace.go
+++ b/client/replace.go
@@ -68,7 +68,7 @@ func (cli *HyperClient) HyperCmdReplace(args ...string) error {
 			return err
 		}
 
-		newPodId, err := cli.CreatePod(jsonbody, false)
+		newPodId, err := cli.CreatePod(jsonbody, false, false)
 		if err != nil {
 			return err
 		}

--- a/client/run.go
+++ b/client/run.go
@@ -82,15 +82,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) error {
 
 	t1 := time.Now()
 
-	var (
-		spec  pod.UserPod
-		async = true
-	)
-	json.Unmarshal([]byte(podJson), &spec)
-
-	vmId, err := cli.CreateVm(spec.Resource.Vcpu, spec.Resource.Memory, async)
-
-	podId, err := cli.CreatePod(podJson, false)
+	podId, err := cli.CreatePod(podJson, false, true)
 	if err != nil {
 		return err
 	}
@@ -105,7 +97,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) error {
 		}()
 	}
 
-	_, err = cli.StartPod(podId, vmId, attach)
+	_, err = cli.StartPod(podId, "", attach)
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -145,7 +145,7 @@ func (daemon *Daemon) Restore() error {
 	defer daemon.PodList.Unlock()
 
 	for k, v := range podList {
-		err = daemon.CreatePod(k, v, false)
+		p, err := daemon.CreatePod(k, v, false)
 		if err != nil {
 			glog.Warningf("Got a unexpected error, %s", err.Error())
 			continue
@@ -155,7 +155,6 @@ func (daemon *Daemon) Restore() error {
 			glog.V(1).Info(err.Error(), " for ", k)
 			continue
 		}
-		p, _ := daemon.PodList.Get(k)
 		if err := p.AssociateVm(daemon, string(vmId)); err != nil {
 			glog.V(1).Info("Some problem during associate vm %s to pod %s, %v", string(vmId), k, err)
 			// continue to next
@@ -336,16 +335,7 @@ func (daemon *Daemon) GetPod(podId, podArgs string, autoremove bool) (*Pod, erro
 		return pod, nil
 	}
 
-	pod, err := CreatePod(daemon, daemon.DockerCli, podId, podArgs, autoremove)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = daemon.AddPod(pod, podArgs); err != nil {
-		return nil, err
-	}
-
-	return pod, nil
+	return daemon.CreatePod(podId, podArgs, autoremove)
 }
 
 func (daemon *Daemon) GetPodByName(podName string) ([]byte, error) {

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -37,11 +37,24 @@ func (daemon *Daemon) CmdPodCreate(job *engine.Job) error {
 	}
 
 	podId := fmt.Sprintf("pod-%s", pod.RandStr(10, "alpha"))
+	glog.V(1).Infof("podArgs: %s", podArgs)
+
+	spec, err := ProcessPodBytes([]byte(podArgs), podId)
+	if err != nil {
+		glog.V(1).Infof("Process POD file error: %s", err.Error())
+		return err
+	}
+
+	if err = spec.Validate(); err != nil {
+		return err
+	}
+
 	daemon.PodList.Lock()
 	glog.V(2).Infof("lock PodList")
 	defer glog.V(2).Infof("unlock PodList")
 	defer daemon.PodList.Unlock()
-	_, err := daemon.CreatePod(podId, podArgs, autoRemove)
+
+	_, err = CreatePod(daemon, daemon.DockerCli, podId, podArgs, spec, autoRemove)
 	if err != nil {
 		return err
 	}

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -41,7 +41,7 @@ func (daemon *Daemon) CmdPodCreate(job *engine.Job) error {
 	glog.V(2).Infof("lock PodList")
 	defer glog.V(2).Infof("unlock PodList")
 	defer daemon.PodList.Unlock()
-	err := daemon.CreatePod(podId, podArgs, autoRemove)
+	_, err := daemon.CreatePod(podId, podArgs, autoRemove)
 	if err != nil {
 		return err
 	}
@@ -339,14 +339,18 @@ func (p *Pod) InitContainers(daemon *Daemon, dclient DockerInterface) (err error
 }
 
 //FIXME: there was a `config` argument passed by docker/builder, but we never processed it.
-func (daemon *Daemon) CreatePod(podId, podArgs string, autoremove bool) error {
+func (daemon *Daemon) CreatePod(podId, podArgs string, autoremove bool) (*Pod, error) {
 
 	pod, err := CreatePod(daemon, daemon.DockerCli, podId, podArgs, autoremove)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return daemon.AddPod(pod, podArgs)
+	if err = daemon.AddPod(pod, podArgs); err != nil {
+		return nil, err
+	}
+
+	return pod, nil
 }
 
 func (p *Pod) PrepareContainers(sd Storage, dclient DockerInterface) (err error) {

--- a/daemon/rm.go
+++ b/daemon/rm.go
@@ -50,6 +50,7 @@ func (daemon *Daemon) CleanPod(podId string) (int, string, error) {
 	if !ok {
 		return -1, "", fmt.Errorf("Can not find that Pod(%s)", podId)
 	}
+	pod.prefetchedVm.cancel(daemon)
 	if pod.status.Status != types.S_POD_RUNNING {
 		// If the pod type is kubernetes, we just remove the pod from the pod list.
 		// The persistent data has been removed since we got the E_VM_SHUTDOWN event.

--- a/lib/docker/builder/dockerfile/internals.go
+++ b/lib/docker/builder/dockerfile/internals.go
@@ -220,7 +220,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	if err != nil {
 		return err
 	}
-	err = b.Hyperdaemon.CreatePod(podId, podString, false)
+	_, err = b.Hyperdaemon.CreatePod(podId, podString, false)
 	if err != nil {
 		return err
 	}

--- a/lib/docker/builder/dockerfile/internals_darwin.go
+++ b/lib/docker/builder/dockerfile/internals_darwin.go
@@ -58,7 +58,7 @@ func (b *Builder) create() (*daemon.Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = b.Hyperdaemon.CreatePod(podId, podString, false)
+	_, err = b.Hyperdaemon.CreatePod(podId, podString, false)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/docker/builder/dockerfile/internals_linux.go
+++ b/lib/docker/builder/dockerfile/internals_linux.go
@@ -59,7 +59,7 @@ func (b *Builder) create() (*daemon.Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = b.Hyperdaemon.CreatePod(podId, podString, false)
+	_, err = b.Hyperdaemon.CreatePod(podId, podString, false)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -609,8 +609,9 @@ func postPodCreate(eng *engine.Engine, version version.Version, w http.ResponseW
 
 	podArgs, _ := ioutil.ReadAll(r.Body)
 	autoRemove := r.Form.Get("remove")
-	glog.V(1).Infof("Args string is %s, %s", string(podArgs), autoRemove)
-	job := eng.Job("podCreate", string(podArgs), autoRemove)
+	prefetchVm := r.Form.Get("prefetchvm")
+	glog.V(1).Infof("Args string is %s, %s, %s", string(podArgs), autoRemove, prefetchVm)
+	job := eng.Job("podCreate", string(podArgs), autoRemove, prefetchVm)
 	stdoutBuf := bytes.NewBuffer(nil)
 
 	job.Stdout.Add(stdoutBuf)


### PR DESCRIPTION
prefetch vm when create pod

use prefetching workflow to run/start pods
implement dummy prefetchVm() (simply calls StartVm())
reduce one step for `hyper run`

move ProcessPodBytes() out from podlist lock