### PR TITLE
test volume sharing, both host to vm and vm to host

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -92,6 +92,17 @@ hyper::test::map_file() {
   test "a$invm" = "a$rslv"
 }
 
+hyper::test::with_volume() {
+  mkdir -p  ${HYPER_TEMP}/tmp
+  echo 'hello, world' > ${HYPER_TEMP}/tmp/with-volume-test-1
+  sed -e "s|TMPDIR|${HYPER_TEMP}/tmp|" ${HYPER_ROOT}/hack/pods/with-volume.pod > ${HYPER_TEMP}/with-volume.pod
+  hyper::test::run_attached_pod ${HYPER_TEMP}/with-volume.pod | grep OK
+  echo "check the out file: ${HYPER_TEMP}/tmp/with-volume-test-2"
+  cat ${HYPER_TEMP}/tmp/with-volume-test-2
+  grep -q OK ${HYPER_TEMP}/tmp/with-volume-test-2
+}
+
 hyper::test::service() {
     hyper::test::run_pod ${HYPER_ROOT}/hack/pods/service.pod
 }
+

--- a/hack/pods/with-volume.pod
+++ b/hack/pods/with-volume.pod
@@ -1,0 +1,47 @@
+{
+	"id": "test-container-volume",
+	"containers" : [{
+	    "name": "c1",
+	    "image": "busybox",
+            "command": ["/bin/sh", "-c", "grep -q 'hello, world' /mnt/with-volume-test-1 && df | grep -q '/var/log' && echo 'container 1 OK'"],
+            "volumes": [{
+                "volume": "log",
+                "path": "/var/log",
+                "readOnly": false
+             },{
+                "volume": "tmp",
+                "path": "/mnt",
+                "readOnly": false
+             }]
+	},
+	{
+	    "name": "c2",
+	    "image": "busybox",
+	    "workdir": "/",
+	    "command": ["/bin/sh", "-c", "echo 'container-2 OK' > /mnt/with-volume-test-2"],
+            "volumes": [{
+                "volume": "log",
+                "path": "/var/log",
+                "readOnly": false
+             },{
+                "volume": "tmp",
+                "path": "/mnt",
+                "readOnly": false
+             }]
+	}],
+	"resource": {
+	    "vcpu": 1,
+	    "memory": 512
+	},
+	"files": [],
+	"volumes": [{
+            "name": "log",
+            "source": "",
+            "driver": ""
+	},{
+            "name": "tmp",
+            "source": "TMPDIR",
+            "driver": "vfs"
+	}],
+	"tty": true
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -158,6 +158,7 @@ __EOF__
   hyper::test::exec
   hyper::test::insert_file
   hyper::test::map_file
+  hyper::test::with_volume
   hyper::test::service
 
   stop_hyperd


### PR DESCRIPTION
this depends on the fix of hyperhq/hyperstart#37

the test pod include 2 containers and 2 volume.

- one volume is mapped from the host, and the other is created
- the first container read files on the volume, check the mount point, and echo string; 
- the second container write string to a file on the shared volume
