### PR TITLE
add vmcache functionality

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -52,6 +52,7 @@ type Daemon struct {
 	DockerCli   DockerInterface
 	PodList     *PodList
 	VmList      map[string]*hypervisor.Vm
+	vmCache     VmCache
 	Kernel      string
 	Initrd      string
 	Bios        string
@@ -247,6 +248,7 @@ func NewDaemonFromDirectory(eng *engine.Engine) (*Daemon, error) {
 		BridgeIP:    bridgeip,
 		BridgeIface: biface,
 	}
+	daemon.vmCache.daemon = daemon
 
 	// Get the docker daemon info
 	sysinfo, err := dockerCli.SendCmdInfo()

--- a/hyperd.go
+++ b/hyperd.go
@@ -211,6 +211,9 @@ func mainDaemon(config, host string, flDisableIptables bool) {
 		return
 	}
 
+	vmCachePolicy, _ := cfg.GetValue(goconfig.DEFAULT_SECTION, "VmCachePolicy")
+	d.InitVmCache(vmCachePolicy)
+
 	// Daemon is fully initialized and handling API traffic
 	// Wait for serve API job to complete
 	select {

--- a/lib/docker/daemon/graphdriver/vbox/driver.go
+++ b/lib/docker/daemon/graphdriver/vbox/driver.go
@@ -112,7 +112,7 @@ func (d *Driver) Setup() (err error) {
 			return err
 		}
 	}
-	vm, err = d.daemon.StartVm(d.pullVm, 1, 64, false, types.VM_KEEP_AFTER_SHUTDOWN)
+	vm, err = d.daemon.StartVm(d.pullVm, 1, 64, false, false, types.VM_KEEP_AFTER_SHUTDOWN)
 	if err != nil {
 		glog.Errorf(err.Error())
 		return err


### PR DESCRIPTION
and hot add cpu/mem when cached vm's cpu or mem is dismatch

the cache is enabled only when VmCachePolicy=cache is set in the
/etc/hyper/config.

it speeds up `hyper run` by 50%~70%.
the slowest part is 'logic cpu online" in the guest, so the future
work would be:
1) speed up it
2) do it when the pod is being created

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>