### PR TITLE
Update centOS RPM build related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,14 @@ mac_installer/dist/opt/hyper/bin/hyper
 mac_installer/dist/opt/hyper/bin/hyperd
 *.bak
 mac_installer/dist/opt/hyper/examples/*
+package/centos/rpm/BUILD/*
+package/centos/rpm/BUILDROOT/*
+package/centos/rpm/SOURCES/*
+package/centos/rpm/RPMS/*
+package/centos/rpm/SRPMS/*
+package/centos/centos-rpm.pod
+package/centos/rpm/SPECS/hyper.spec
+package/centos/rpm/SPECS/hyperstart.spec
 
 # supporting linux container on non-linux platform
 /Godeps/_workspace/src/github.com/opencontainers/specs/config-linux.go

--- a/hack/pods/with-volume.pod
+++ b/hack/pods/with-volume.pod
@@ -3,7 +3,7 @@
 	"containers" : [{
 	    "name": "c1",
 	    "image": "busybox",
-            "command": ["/bin/sh", "-c", "grep -q 'hello, world' /mnt/with-volume-test-1 && df | grep -q '/var/log' && echo 'container 1 OK'"],
+            "command": ["/bin/sh", "-c", "grep -q 'hello, world' /mnt/with-volume-test-1 && df | grep -q '/var/log' && echo 'container 1 OK' ; sleep 1"],
             "volumes": [{
                 "volume": "log",
                 "path": "/var/log",

--- a/package/centos/Dockerfile
+++ b/package/centos/Dockerfile
@@ -3,18 +3,17 @@ MAINTAINER Xu Wang <xu@hyper.sh>
 
 # RPM Build Environment
 RUN yum install -y @development-tools centos-packager rpmdevtools
-RUN /usr/sbin/useradd makerpm
-RUN usermod -a -G mock makerpm
-RUN su makerpm -c 'rpmdev-setuptree'
+RUN /usr/sbin/useradd makerpm; usermod -a -G mock makerpm; su makerpm -c 'rpmdev-setuptree'
 
 # Hyper dependency
-RUN yum install -y automake autoconf gcc make glibc-devel glibc-devel.i686
-RUN yum install -y device-mapper-devel pcre-devel libsepol-devel libselinux-devel systemd-container-devel
-RUN yum install -y sqlite-devel
+RUN yum install -y automake autoconf gcc make glibc-devel glibc-devel.i686 device-mapper-devel pcre-devel libsepol-devel libselinux-devel systemd-container-devel sqlite-devel
 RUN curl -sL https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz | tar -C /usr/local -zxf -
 
 # CBFSTool
 RUN cd /dev/shm; curl -sSL https://www.coreboot.org/releases/coreboot-4.2.tar.xz | tar --xz -xvf - ; cd coreboot-4.2/util/cbfstool ; make; cp cbfstool /usr/local/bin/
+
+# Qemu Denpendency
+RUN yum install -y gcc-c++ zlib-devel libcap-devel libattr-devel librbd1-devel libtool
 
 ENV PATH /usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/package/centos/make-rpm.sh
+++ b/package/centos/make-rpm.sh
@@ -17,12 +17,16 @@ git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/runv-${VERSION}.t
 cd $PROJECT/../hyperstart
 git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/hyperstart-${VERSION}.tar.gz
 cd ..
+[ -d qboot ] && rm -rf qboot
 git clone https://github.com/bonzini/qboot.git
 cd qboot
 git archive --format=tar.gz master > ${CENTOS_DIR}/rpm/SOURCES/qboot.tar.gz
+curl -sSL http://wiki.qemu-project.org/download/qemu-2.4.1.tar.bz2 > ${CENTOS_DIR}/rpm/SOURCES/qemu-2.4.1.tar.bz2
 
 
 sed -e "s#%PROJECT_ROOT%#${PROJECT}#g" ${CENTOS_DIR}/centos-rpm.pod.in > ${CENTOS_DIR}/centos-rpm.pod
 sed -e "s#%VERSION%#${VERSION}#g" ${CENTOS_DIR}/rpm/SPECS/hyper.spec.in > ${CENTOS_DIR}/rpm/SPECS/hyper.spec
 sed -e "s#%VERSION%#${VERSION}#g" ${CENTOS_DIR}/rpm/SPECS/hyperstart.spec.in > ${CENTOS_DIR}/rpm/SPECS/hyperstart.spec
+
+${PROJECT}/hyper run -a --rm -p ${CENTOS_DIR}/centos-rpm.pod
 

--- a/package/centos/rpm/SPECS/hyperstart.spec.in
+++ b/package/centos/rpm/SPECS/hyperstart.spec.in
@@ -1,7 +1,7 @@
 Summary:            Hyperstart is the initrd for hyper VM
 Name:               hyperstart
 Version:            %VERSION%
-Release:            1%{?dist}
+Release:            2%{?dist}
 License:            Apache License, Version 2.0
 Group:              System Environment/Base
 # The source for this package was pulled from upstream's git repo. Use the
@@ -37,8 +37,8 @@ make
 mkdir -p %{buildroot}%{_sharedstatedir}/hyper
 cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/kernel %{buildroot}%{_sharedstatedir}/hyper/
 cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/hyper-initrd.img %{buildroot}%{_sharedstatedir}/hyper/
-cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/cbfs.rom %{buildroot}%{_sharedstatedir}/hyper/qboot-cbfs.rom
-cp %{_builddir}/src/qboot/bios.bin %{buildroot}%{_sharedstatedir}/hyper/qboot-bios.bin
+cp %{_builddir}/src/github.com/hyperhq/hyperstart/build/cbfs.rom %{buildroot}%{_sharedstatedir}/hyper/cbfs-qboot.rom
+cp %{_builddir}/src/qboot/bios.bin %{buildroot}%{_sharedstatedir}/hyper/bios-qboot.bin
 
 %clean
 rm -rf %{buildroot}
@@ -47,5 +47,7 @@ rm -rf %{buildroot}
 %{_sharedstatedir}/*
 
 %changelog
+* Fri Jan 29 2016 Xu Wang <xu@hyper.sh> - 0.4-2
+- Fix firmware path
 * Sat Nov 21 2015 Xu Wang <xu@hyper.sh> - 0.4-1
 - Initial rpm packaging for hyperstart

--- a/package/centos/rpm/SPECS/qemu-hyper.spec
+++ b/package/centos/rpm/SPECS/qemu-hyper.spec
@@ -1,0 +1,43 @@
+Summary:            Hyper build Qemu with virtfs support
+Name:               qemu-hyper
+Version:            2.4.1
+Release:            2%{?dist}
+License:            Apache License, Version 2.0
+Group:              System Environment/Base
+Source0:            http://wiki.qemu-project.org/download/qemu-2.4.1.tar.bz2
+URL:                https://qemu-project.org
+ExclusiveArch:      x86_64
+Requires:           librbd1
+BuildRequires:      libcap-devel,libattr-devel,librbd1-devel
+
+%define _unpackaged_files_terminate_build 0
+%define _missing_doc_files_terminate_build 0
+
+%description
+Qemu is the powerful and popular Hardware emulator
+Hyper build is for x86_64 arch and enable virtfs and rbd support
+
+%prep
+%autosetup -n qemu-2.4.1
+
+%build
+cd %{_builddir}/qemu-2.4.1
+./configure --prefix=/usr --enable-virtfs --enable-rbd --disable-fdt --disable-vnc  --disable-guest-agent --audio-drv-list="" --disable-tpm --target-list=x86_64-softmmu
+make
+
+%install
+%make_install
+
+%clean
+#rm -rf %{buildroot}
+
+%files
+%{_bindir}/qemu-system-x86_64
+%{_datadir}/qemu/efi-virtio.rom
+
+%changelog
+* Fri Jan 29 2016 Xu Wang <xu@hyper.sh> - 2.4.1-2
+- Include virtio firmware
+- Include librbd dependency
+* Wed Dec 2 2015 Xu Wang <xu@hyper.sh> - 2.4.1-1
+- config with virtfs and rbd

--- a/package/centos/rpm/build.sh
+++ b/package/centos/rpm/build.sh
@@ -2,3 +2,7 @@
 
 su makerpm -c "rpmbuild -ba hyper.spec"
 su makerpm -c "rpmbuild -ba hyperstart.spec"
+su makerpm -c "rpmbuild -ba qemu-hyper.spec"
+ls -lh ../RPMS/x86_64
+sleep 60
+sync

--- a/package/dist/lib/systemd/system/hyperd.service
+++ b/package/dist/lib/systemd/system/hyperd.service
@@ -5,7 +5,7 @@ After=network.target
 Requires=
 
 [Service]
-ExecStart=/usr/bin/hyperd
+ExecStart=/usr/bin/hyperd --nondaemon --log_dir=/var/log/hyper
 MountFlags=shared
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
- include QEMU package for centOS
- fix mistakes in the previous package files

Based on tests on CentOS 7.2 and user reports, the RPMs fixed the CentOS 7.x installations
