### PR TITLE
Fix command line argument process

### DIFF
--- a/client/attach.go
+++ b/client/attach.go
@@ -14,7 +14,7 @@ import (
 func (cli *HyperClient) HyperCmdAttach(args ...string) error {
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "attach CONTAINER\n\nAttach to the tty of a specified container in a pod"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -22,11 +22,11 @@ func (cli *HyperClient) HyperCmdAttach(args ...string) error {
 			return nil
 		}
 	}
-	if len(args) == 1 {
+	if len(args) == 0 {
 		return fmt.Errorf("Can not accept the 'attach' command without Container ID!")
 	}
 	var (
-		podName     = args[1]
+		podName     = args[0]
 		tag         = cli.GetTag()
 		containerId = podName
 	)

--- a/client/build.go
+++ b/client/build.go
@@ -27,9 +27,6 @@ import (
 
 // hyper build [OPTIONS] PATH
 func (cli *HyperClient) HyperCmdBuild(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("%s ERROR: Can not accept the 'run' command without argument!\n", os.Args[0])
-	}
 	var opts struct {
 		ImageName      string `long:"tag" short:"t" default:"" value-name:"\"\"" default-mask:"-" description:"Repository name (and optionally a tag) to be applied to the resulting image in case of success"`
 		DockerfileName string `long:"file" short:"f" default:"" value-name:"\"\"" default-mask:"-" description:"Customized docker file"`
@@ -37,7 +34,7 @@ func (cli *HyperClient) HyperCmdBuild(args ...string) error {
 
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "build [OPTIONS] PATH\n\nBuild a new image from the source code at PATH"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -54,7 +51,7 @@ func (cli *HyperClient) HyperCmdBuild(args ...string) error {
 		context  archive.Archive
 		name     = ""
 	)
-	root := args[1]
+	root := args[0]
 	if _, err := os.Stat(root); err != nil {
 		return err
 	}

--- a/client/commit.go
+++ b/client/commit.go
@@ -29,7 +29,7 @@ func (cli *HyperClient) HyperCmdCommit(args ...string) error {
 	var parser = gflag.NewParser(&opts, gflag.Default)
 
 	parser.Usage = "commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]\n\nCreate a new image from a container's changes"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -44,11 +44,11 @@ func (cli *HyperClient) HyperCmdCommit(args ...string) error {
 		containerId string = ""
 		repo        string = ""
 	)
-	if len(args) > 1 {
-		containerId = args[1]
+	if len(args) > 0 {
+		containerId = args[0]
 	}
-	if len(args) > 2 {
-		repo = args[2]
+	if len(args) > 1 {
+		repo = args[1]
 	}
 	v := url.Values{}
 	v.Set("author", opts.Author)

--- a/client/create.go
+++ b/client/create.go
@@ -8,15 +8,12 @@ import (
 )
 
 func (cli *HyperClient) HyperCmdCreate(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("\"create\" requires a minimum of 1 argument, please provide POD spec file.\n")
-	}
 	var opts struct {
 		Yaml bool `short:"y" long:"yaml" default:"false" default-mask:"-" description:"create a pod based on Yaml file"`
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "create [OPTIONS] POD_FILE\n\nCreate a pod into 'pending' status, but without running it"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -24,7 +21,10 @@ func (cli *HyperClient) HyperCmdCreate(args ...string) error {
 			return nil
 		}
 	}
-	jsonFile := args[1]
+	if len(args) == 0 {
+		return fmt.Errorf("\"create\" requires a minimum of 1 argument, please provide POD spec file.\n")
+	}
+	jsonFile := args[0]
 
 	jsonbody, err := cli.JsonFromFile(jsonFile, opts.Yaml, false)
 	if err != nil {

--- a/client/exec.go
+++ b/client/exec.go
@@ -54,7 +54,7 @@ func (cli *HyperClient) HyperCmdExec(args ...string) error {
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default|gflag.IgnoreUnknown)
 	parser.Usage = "exec [OPTIONS] POD|CONTAINER COMMAND [ARGS...]\n\nRun a command in a container of a running pod"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -62,18 +62,18 @@ func (cli *HyperClient) HyperCmdExec(args ...string) error {
 			return nil
 		}
 	}
-	if len(args) == 1 {
+	if len(args) == 0 {
 		return fmt.Errorf("Can not accept the 'exec' command without POD/Container ID!")
 	}
-	if len(args) == 2 {
+	if len(args) == 1 {
 		return fmt.Errorf("Can not accept the 'exec' command without command!")
 	}
 	var (
-		podName     = args[1]
+		podName     = args[0]
 		tag         = cli.GetTag()
 		containerId string
 	)
-	command, err := json.Marshal(args[2:])
+	command, err := json.Marshal(args[1:])
 	if err != nil {
 		return err
 	}

--- a/client/images.go
+++ b/client/images.go
@@ -21,7 +21,7 @@ func (cli *HyperClient) HyperCmdImages(args ...string) error {
 	var parser = gflag.NewParser(&opts, gflag.Default)
 
 	parser.Usage = "images [OPTIONS] [REPOSITORY]\n\nList images"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err

--- a/client/info.go
+++ b/client/info.go
@@ -13,7 +13,7 @@ import (
 func (cli *HyperClient) HyperCmdInfo(args ...string) error {
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "info\n\nDisplay system-wide information"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err

--- a/client/kill.go
+++ b/client/kill.go
@@ -14,7 +14,7 @@ import (
 func (cli *HyperClient) HyperCmdKill(args ...string) error {
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "kill VM_ID\n\nTerminate a VM instance"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -22,11 +22,11 @@ func (cli *HyperClient) HyperCmdKill(args ...string) error {
 			return nil
 		}
 	}
-	if len(args) == 1 {
+	if len(args) == 0 {
 		return fmt.Errorf("\"kill\" requires a minimum of 1 argument, please provide VM ID.\n")
 	}
 
-	vmId := args[1]
+	vmId := args[0]
 	v := url.Values{}
 	v.Set("vm", vmId)
 	body, _, err := readBody(cli.call("DELETE", "/vm?"+v.Encode(), nil, nil))

--- a/client/list.go
+++ b/client/list.go
@@ -21,7 +21,7 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 
 	var parser = gflag.NewParser(&opts, gflag.Default|gflag.IgnoreUnknown)
 	parser.Usage = "list [OPTIONS] [pod|container|vm]\n\nlist all pods or container information"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -30,10 +30,10 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 		}
 	}
 	var item string
-	if len(args) == 1 {
+	if len(args) == 0 {
 		item = "pod"
 	} else {
-		item = args[1]
+		item = args[0]
 	}
 
 	if item != "pod" && item != "vm" && item != "container" {

--- a/client/login.go
+++ b/client/login.go
@@ -29,7 +29,7 @@ func (cli *HyperClient) HyperCmdLogin(args ...string) error {
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "login [SERVER]\n\nRegister or log in to a Docker registry server, if no server is\nspecified \"" + registry.IndexServer + "\" is the default."
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -41,8 +41,8 @@ func (cli *HyperClient) HyperCmdLogin(args ...string) error {
 	password := opts.Password
 	email := opts.Email
 	serverAddress := registry.IndexServer
-	if len(args) > 1 {
-		serverAddress = args[1]
+	if len(args) > 0 {
+		serverAddress = args[0]
 	}
 
 	promptDefault := func(prompt string, configDefault string) {

--- a/client/logout.go
+++ b/client/logout.go
@@ -17,7 +17,7 @@ import (
 func (cli *HyperClient) HyperCmdLogout(args ...string) error {
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "logout [SERVER]\n\nLog out from a Docker registry, if no server is\nspecified \"" + registry.IndexServer + "\" is the default."
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -26,8 +26,8 @@ func (cli *HyperClient) HyperCmdLogout(args ...string) error {
 		}
 	}
 	serverAddress := registry.IndexServer
-	if len(args) > 1 {
-		serverAddress = args[1]
+	if len(args) > 0 {
+		serverAddress = args[0]
 	}
 
 	if _, ok := cli.configFile.AuthConfigs[serverAddress]; !ok {

--- a/client/logs.go
+++ b/client/logs.go
@@ -22,7 +22,7 @@ func (cli *HyperClient) HyperCmdLogs(args ...string) error {
 
 	var parser = gflag.NewParser(&opts, gflag.Default|gflag.IgnoreUnknown)
 	parser.Usage = "logs CONTAINER [OPTIONS...]\n\nFetch the logs of a container"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -31,12 +31,12 @@ func (cli *HyperClient) HyperCmdLogs(args ...string) error {
 		}
 	}
 
-	if len(args) <= 1 {
+	if len(args) == 0 {
 		return fmt.Errorf("%s ERROR: Can not accept the 'logs' command without argument!\n", os.Args[0])
 	}
 
 	v := url.Values{}
-	v.Set("container", args[1])
+	v.Set("container", args[0])
 	v.Set("stdout", "yes")
 	v.Set("stderr", "yes")
 

--- a/client/pod.go
+++ b/client/pod.go
@@ -21,7 +21,7 @@ func (cli *HyperClient) HyperCmdPod(args ...string) error {
 	t1 := time.Now()
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "pod POD_FILE\n\nCreate a pod, initialize a pod and run it"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -29,10 +29,10 @@ func (cli *HyperClient) HyperCmdPod(args ...string) error {
 			return nil
 		}
 	}
-	if len(args) < 2 {
+	if len(args) == 0 {
 		return fmt.Errorf("\"pod\" requires a minimum of 1 argument, please provide POD spec file.\n")
 	}
-	jsonFile := args[1]
+	jsonFile := args[0]
 	if _, err := os.Stat(jsonFile); err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (cli *HyperClient) HyperCmdStart(args ...string) error {
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "start [-c 1 -m 128]| POD_ID \n\nLaunch a 'pending' pod"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -153,19 +153,15 @@ func (cli *HyperClient) HyperCmdStart(args ...string) error {
 		fmt.Printf("New VM id is %s\n", remoteInfo.Get("ID"))
 		return nil
 	}
-	if len(args) < 2 {
+	if len(args) == 0 {
 		return fmt.Errorf("\"start\" requires a minimum of 1 argument, please provide POD ID.\n")
 	}
 	var (
-		podId string
+		podId = args[0]
 		vmId  string
 	)
-	if len(args) == 2 {
-		podId = args[1]
-	}
-	if len(args) == 3 {
-		podId = args[1]
-		vmId = args[2]
+	if len(args) >= 2 {
+		vmId = args[1]
 	}
 	// fmt.Printf("Pod ID is %s, VM ID is %s\n", podId, vmId)
 	_, err = cli.StartPod(podId, vmId, false)

--- a/client/pull.go
+++ b/client/pull.go
@@ -13,13 +13,9 @@ import (
 )
 
 func (cli *HyperClient) HyperCmdPull(args ...string) error {
-	// we need to get the image name which will be used to create a container
-	if len(args) == 0 {
-		return fmt.Errorf("\"pull\" requires a minimum of 1 argument, please provide the image name.")
-	}
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "pull IMAGE\n\npull an image from a Docker registry server"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -27,7 +23,11 @@ func (cli *HyperClient) HyperCmdPull(args ...string) error {
 			return nil
 		}
 	}
-	return cli.PullImage(args[1])
+	// we need to get the image name which will be used to create a container
+	if len(args) == 0 {
+		return fmt.Errorf("\"pull\" requires a minimum of 1 argument, please provide the image name.")
+	}
+	return cli.PullImage(args[0])
 }
 
 func (cli *HyperClient) PullImage(imageName string) error {

--- a/client/push.go
+++ b/client/push.go
@@ -15,13 +15,9 @@ import (
 //
 // Usage: hyper push NAME[:TAG]
 func (cli *HyperClient) HyperCmdPush(args ...string) error {
-	// we need to get the image name which will be used to create a container
-	if len(args) == 0 {
-		return fmt.Errorf("\"push\" requires a minimum of 1 argument, please provide the image name.")
-	}
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "push NAME[:TAG]\n\nPush an image to a Docker registry server"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -29,7 +25,11 @@ func (cli *HyperClient) HyperCmdPush(args ...string) error {
 			return nil
 		}
 	}
-	name := args[1]
+	// we need to get the image name which will be used to create a container
+	if len(args) == 0 {
+		return fmt.Errorf("\"push\" requires a minimum of 1 argument, please provide the image name.")
+	}
+	name := args[0]
 	remote, tag := parsers.ParseRepositoryTag(name)
 
 	// Resolve the Repository name from fqn to RepositoryInfo

--- a/client/replace.go
+++ b/client/replace.go
@@ -4,7 +4,6 @@ package client
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hyperhq/runv/hypervisor/types"
@@ -13,10 +12,6 @@ import (
 )
 
 func (cli *HyperClient) HyperCmdReplace(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("\"replace\" requires a minimum of 1 argument, \"%s replace --help\" may provide more details.\n", os.Args[0])
-	}
-
 	var opts struct {
 		OldPod  string `short:"o" long:"oldpod" value-name:"\"\"" description:"The Pod which will be replaced, must be 'running' status"`
 		NewPod  string `short:"n" long:"newpod" value-name:"\"\"" description:"The Pod which will be running, must be 'pending' status"`
@@ -25,7 +20,7 @@ func (cli *HyperClient) HyperCmdReplace(args ...string) error {
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "replace --oldpod POD_ID --newpod POD_ID [--file POD_FILE]\n\nReplace the pod in a running VM with a new one"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -33,6 +28,7 @@ func (cli *HyperClient) HyperCmdReplace(args ...string) error {
 			return nil
 		}
 	}
+
 	oldPodId := opts.OldPod
 	if oldPodId == "" {
 		return fmt.Errorf("Please provide the old pod which you want to replace!")

--- a/client/rm.go
+++ b/client/rm.go
@@ -14,7 +14,7 @@ import (
 func (cli *HyperClient) HyperCmdRm(args ...string) error {
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "rm POD [POD...]\n\nRemove one or more pods"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -22,10 +22,10 @@ func (cli *HyperClient) HyperCmdRm(args ...string) error {
 			return nil
 		}
 	}
-	if len(args) < 2 {
+	if len(args) == 0 {
 		return fmt.Errorf("\"rm\" requires a minimum of 1 argument, please provide POD ID.\n")
 	}
-	pods := args[1:]
+	pods := args
 	for _, id := range pods {
 		err := cli.RmPod(id)
 		if err == nil {

--- a/client/rmi.go
+++ b/client/rmi.go
@@ -18,7 +18,7 @@ func (cli *HyperClient) HyperCmdRmi(args ...string) error {
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "rmi [OPTIONS] IMAGE [IMAGE...]\n\nRemove one or more images"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -30,7 +30,7 @@ func (cli *HyperClient) HyperCmdRmi(args ...string) error {
 		noprune string = "no"
 		force   string = "yes"
 	)
-	if len(args) < 2 {
+	if len(args) == 0 {
 		return fmt.Errorf("\"rmi\" requires a minimum of 1 argument, please provide IMAGE ID.\n")
 	}
 	if opts.Noprune == true {
@@ -39,7 +39,7 @@ func (cli *HyperClient) HyperCmdRmi(args ...string) error {
 	if opts.Force == false {
 		force = "no"
 	}
-	images := args[1:]
+	images := args
 	for _, imageId := range images {
 		v := url.Values{}
 		v.Set("imageId", imageId)

--- a/client/run.go
+++ b/client/run.go
@@ -21,9 +21,6 @@ import (
 
 // hyper run [OPTIONS] image [COMMAND] [ARGS...]
 func (cli *HyperClient) HyperCmdRun(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("%s ERROR: Can not accept the 'run' command without argument!\n", os.Args[0])
-	}
 	var opts struct {
 		PodFile       string   `short:"p" long:"podfile" value-name:"\"\"" description:"Create and Run a pod based on the pod file"`
 		K8s           string   `short:"k" long:"kubernetes" value-name:"\"\"" description:"Create and Run a pod based on the kubernetes pod file"`
@@ -47,7 +44,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) error {
 
 	var parser = gflag.NewParser(&opts, gflag.Default|gflag.IgnoreUnknown)
 	parser.Usage = "run [OPTIONS] IMAGE [COMMAND] [ARG...]\n\nCreate a pod, and launch a new VM to run the pod"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -72,7 +69,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) error {
 			return fmt.Errorf("%s: \"run\" requires a minimum of 1 argument, please provide the image.", os.Args[0])
 		}
 		attach = !opts.Detach
-		podJson, err = cli.JsonFromCmdline(args[1:], opts.Env, opts.Portmap, opts.LogDriver, opts.LogOpts,
+		podJson, err = cli.JsonFromCmdline(args, opts.Env, opts.Portmap, opts.LogDriver, opts.LogOpts,
 			opts.Name, opts.Workdir, opts.RestartPolicy, opts.Cpu, opts.Memory, opts.Tty, opts.Labels)
 	}
 
@@ -155,7 +152,6 @@ func (cli *HyperClient) JsonFromFile(filename string, yaml, k8s bool) (string, e
 	return string(jsonbody), nil
 }
 
-// cmdArgs: args[1:]
 func (cli *HyperClient) JsonFromCmdline(cmdArgs, cmdEnvs, cmdPortmaps []string, cmdLogDriver string, cmdLogOpts []string,
 	cmdName, cmdWorkdir, cmdRestartPolicy string, cpu, memory int, tty bool, cmdLabels []string) (string, error) {
 

--- a/client/stop.go
+++ b/client/stop.go
@@ -18,7 +18,7 @@ func (cli *HyperClient) HyperCmdStop(args ...string) error {
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "stop POD_ID\n\nStop a running pod"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err
@@ -26,11 +26,11 @@ func (cli *HyperClient) HyperCmdStop(args ...string) error {
 			return nil
 		}
 	}
-	if len(args) == 1 {
+	if len(args) == 0 {
 		return fmt.Errorf("\"stop\" requires a minimum of 1 argument, please provide POD ID.\n")
 	}
 
-	podID := args[1]
+	podID := args[0]
 	stopVm := "yes"
 	if opts.Novm {
 		stopVm = "no"

--- a/client/vm.go
+++ b/client/vm.go
@@ -15,7 +15,7 @@ import (
 func (cli *HyperClient) HyperCmdVm(args ...string) error {
 	var parser = gflag.NewParser(nil, gflag.Default)
 	parser.Usage = "vm\n\nRun a VM, without any Pod running on it"
-	args, err := parser.Parse()
+	args, err := parser.ParseArgs(args)
 	if err != nil {
 		if !strings.Contains(err.Error(), "Usage") {
 			return err


### PR DESCRIPTION
There are several bugs/issue in client command line argument processing, for example

    hyper run -t

or

    hyper build -t "myrepo/myimg"

the above incorrect command line will lead to client panic.

The other problem details include:

## Parse or ParseArgs

In short `Parse()` process os.Args[1:] and `ParseArgs(args []string)` process `args`

The commands have `args` in command line, such as

    func (cli *HyperClient) HyperCmdBuild(args ...string) error

when user types ` hyper build -t "myrepo/myimg"`

- the `args` will be `-t`, `myrepo/myimg`
- the `os.Args` should be `hyper`, `build`, `-t`, `myrepo/myimg`

if we use

    args, err := parser.Parse()

the args will be `build`, and if we check if it is empty, it will never be empty,
because it always has a `build` here even if we forget to provide the path

And if we use

    args, err := parser.ParseArgs(args)

We will get an empty array, through which we can find the input error.

As we have already provide args as the method parameter, we should use
`ParseArgs`

## Should not check args len at the very beginning

we checked `len(args)` some of commands before argument processing,
for example, the `run` checked.

However, if we input `hyper run -t`, it won't find the problem because it has
a `-t`, the problems will be found by following parameters check. The pre-processing
check is trivial.
