### PR TITLE
Fix list of auxiliary containers

### DIFF
--- a/client/list.go
+++ b/client/list.go
@@ -16,7 +16,7 @@ func (cli *HyperClient) HyperCmdList(args ...string) error {
 	var opts struct {
 		Aux bool   `short:"x" long:"aux" default:"false" value-name:"false" description:"show the auxiliary containers"`
 		Pod string `short:"p" long:"pod" value-name:"\"\"" description:"only list the specified pod"`
-		VM  string `short:"m" long:"vm" value-name:"\"\"" description:"only list  resources on the specified vm"`
+		VM  string `short:"m" long:"vm" value-name:"\"\"" description:"only list resources on the specified vm"`
 	}
 
 	var parser = gflag.NewParser(&opts, gflag.Default|gflag.IgnoreUnknown)

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -189,10 +189,9 @@ func showPod(pod *hypervisor.PodStatus) string {
 }
 
 func showPodContainers(pod *hypervisor.PodStatus, aux bool) []string {
-
 	rsp := []string{}
 	filterServiceDiscovery := !aux && (pod.Type == "service-discovery")
-	proxyName := ServiceDiscoveryContainerName(pod.Name)
+	proxyName := "/" + ServiceDiscoveryContainerName(pod.Name)
 
 	for _, c := range pod.Containers {
 		if filterServiceDiscovery && c.Name == proxyName {


### PR DESCRIPTION
Do not list auxiliary containers by default.

```sh
[root@local ~]# hyper list container
Container ID                                                       Name                                                                           POD ID              Status
a8595b5c984c503346918e48e814b5c62892b7a9bd53fc5e34109a8d551abd8d   kube_c3942e3c-c987-11e5-973f-064a4ed57913_busybox_default_busybox_4_88252a0b   pod-CdFTzmUyKQ      running
[root@local ~]# hyper list container -x
Container ID                                                       Name                                                                           POD ID              Status
ba530ef43240182e5bf6b142ea90ddb41bd1403e90e805e148f73c7c711116ee   busybox_default-service-discovery                                              pod-CdFTzmUyKQ      running
a8595b5c984c503346918e48e814b5c62892b7a9bd53fc5e34109a8d551abd8d   kube_c3942e3c-c987-11e5-973f-064a4ed57913_busybox_default_busybox_4_88252a0b   pod-CdFTzmUyKQ      running
```