### PR TITLE
fix errors from "go tool vet ."

### DIFF
--- a/client/images.go
+++ b/client/images.go
@@ -93,5 +93,4 @@ func getImageSizeString(size string) string {
 		rtn = float64(s) / (1024.0 * 1024.0)
 		return fmt.Sprintf("%.1f MB", rtn)
 	}
-	return ""
 }

--- a/client/info.go
+++ b/client/info.go
@@ -72,5 +72,4 @@ func getMemSizeString(s int) string {
 		rtn = float64(s) / (1024.0 * 1024.0 * 1024.0)
 		return fmt.Sprintf("%.1f GB", rtn)
 	}
-	return "0"
 }

--- a/daemon/tty.go
+++ b/daemon/tty.go
@@ -35,7 +35,7 @@ func (daemon *Daemon) TtyResize(podId, tag string, h, w int) error {
 
 	vm, ok := daemon.VmList[vmid]
 	if !ok {
-		return fmt.Errorf("vm %s doesn't exist!")
+		return fmt.Errorf("vm %s doesn't exist!", vmid)
 	}
 
 	err = vm.Tty(tag, h, w)


### PR DESCRIPTION
client/images.go:96: unreachable code
client/info.go:75: unreachable code
daemon/tty.go:38: missing argument for Errorf("%s"): format reads arg 1,
have only 0 args

Signed-off-by: Lai Jiangshan <jiangshanlai@gmail.com>