### PR TITLE
hyper client cmd line option cleanup

### DIFF
--- a/client/commit.go
+++ b/client/commit.go
@@ -15,16 +15,16 @@ import (
 /*
 	-a, --author=       Author (e.g., "Hello World <hello@a-team.com>")
 	-c, --change=[]     Apply Dockerfile instruction to the created image
-	--help=false        Print usage
 	-m, --message=      Commit message
-	-p, --pause=true    Pause container during Commit
+	-p, --pause         Pause container during Commit
+	-h, --help          Print usage
 */
 func (cli *HyperClient) HyperCmdCommit(args ...string) error {
 	var opts struct {
 		Author  string   `short:"a" long:"author" default:"" value-name:"\"\"" description:"Author (e.g., \"Hello World <hello@a-team.com>\")"`
 		Change  []string `short:"c" long:"change" default:"" value-name:"[]" description:"Apply Dockerfile instruction to the created image"`
 		Message string   `short:"m" long:"message" default:"" value-name:"\"\"" description:"Commit message"`
-		Pause   bool     `short:"p" long:"pause" default:"false" value-name:"true" description:"Pause container during Commit"`
+		Pause   bool     `short:"p" long:"pause" default:"false" description:"Pause container during Commit"`
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 

--- a/client/exec.go
+++ b/client/exec.go
@@ -49,8 +49,8 @@ func GetExitCode(cli *HyperClient, container, tag string) error {
 
 func (cli *HyperClient) HyperCmdExec(args ...string) error {
 	var opts struct {
-		Attach bool `short:"a" long:"attach" default:"true" value-name:"false" description:"attach current terminal to the stdio of command"`
-		Vm     bool `long:"vm" default:"false" value-name:"false" description:"attach to vm"`
+		Attach bool `short:"a" long:"attach" default:"true" description:"attach current terminal to the stdio of command"`
+		Vm     bool `long:"vm" default:"false" description:"attach to vm"`
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default|gflag.IgnoreUnknown)
 	parser.Usage = "exec [OPTIONS] POD|CONTAINER COMMAND [ARGS...]\n\nRun a command in a container of a running pod"

--- a/client/images.go
+++ b/client/images.go
@@ -15,8 +15,8 @@ import (
 
 func (cli *HyperClient) HyperCmdImages(args ...string) error {
 	var opts struct {
-		All bool `short:"a" long:"all" default:"false" value-name:"false" description:"Show all images (by default filter out the intermediate image layers)"`
-		Num bool `short:"q" long:"quiet" default:"false" value-name:"false" description:"Only show numeric IDs"`
+		All bool `short:"a" long:"all" default:"false" description:"Show all images (by default filter out the intermediate image layers)"`
+		Num bool `short:"q" long:"quiet" default:"false" description:"Only show numeric IDs"`
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 

--- a/client/list.go
+++ b/client/list.go
@@ -14,7 +14,7 @@ import (
 
 func (cli *HyperClient) HyperCmdList(args ...string) error {
 	var opts struct {
-		Aux bool   `short:"x" long:"aux" default:"false" value-name:"false" description:"show the auxiliary containers"`
+		Aux bool   `short:"x" long:"aux" default:"false" description:"show the auxiliary containers"`
 		Pod string `short:"p" long:"pod" value-name:"\"\"" description:"only list the specified pod"`
 		VM  string `short:"m" long:"vm" value-name:"\"\"" description:"only list resources on the specified vm"`
 	}

--- a/client/pod.go
+++ b/client/pod.go
@@ -102,7 +102,7 @@ func (cli *HyperClient) CreatePod(jsonbody string, remove bool) (string, error) 
 
 func (cli *HyperClient) HyperCmdStart(args ...string) error {
 	var opts struct {
-		// OnlyVm    bool     `long:"onlyvm" default:"false" value-name:"false" description:"Only start a new VM"`
+		// OnlyVm    bool     `long:"onlyvm" default:"false" description:"Only start a new VM"`
 		Cpu int `short:"c" long:"cpu" default:"1" value-name:"1" description:"CPU number for the VM"`
 		Mem int `short:"m" long:"memory" default:"128" value-name:"128" description:"Memory size (MB) for the VM"`
 	}

--- a/client/rmi.go
+++ b/client/rmi.go
@@ -14,7 +14,7 @@ import (
 func (cli *HyperClient) HyperCmdRmi(args ...string) error {
 	var opts struct {
 		Noprune bool `long:"no-prune" default:"false" default-mask:"-" description:"Do not delete untagged parents"`
-		Force   bool `short:"f" long:"force" default:"true" default-mask:"-" description:"Force removal of the image"`
+		Force   bool `short:"f" long:"force" default:"false" default-mask:"-" description:"Force removal of the image"`
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "rmi [OPTIONS] IMAGE [IMAGE...]\n\nRemove one or more images"

--- a/client/run.go
+++ b/client/run.go
@@ -37,7 +37,7 @@ func (cli *HyperClient) HyperCmdRun(args ...string) (err error) {
 		RestartPolicy string   `long:"restart" default:"never" value-name:"\"\"" default-mask:"-" description:"Restart policy to apply when a container exits (never, onFailure, always)"`
 		LogDriver     string   `long:"log-driver" value-name:"\"\"" description:"Logging driver for Pod"`
 		LogOpts       []string `long:"log-opt" description:"Log driver options"`
-		Remove        bool     `long:"rm" default:"false" value-name:"" default-mask:"-" description:"Automatically remove the pod when it exits"`
+		Remove        bool     `long:"rm" default:"false" default-mask:"-" description:"Automatically remove the pod when it exits"`
 		Portmap       []string `long:"publish" value-name:"[]" default-mask:"-" description:"Publish a container's port to the host, format: --publish [tcp/udp:]hostPort:containerPort"`
 		Labels        []string `long:"label" value-name:"[]" default-mask:"-" description:"Add labels for Pod, format: --label key=value"`
 	}

--- a/client/stop.go
+++ b/client/stop.go
@@ -14,7 +14,7 @@ import (
 func (cli *HyperClient) HyperCmdStop(args ...string) error {
 
 	var opts struct {
-		Novm bool `long:"onlypod" default:"false" value-name:"false" description:"Stop a Pod, but left the VM running"`
+		Novm bool `long:"onlypod" default:"false" description:"Stop a Pod, but left the VM running"`
 	}
 	var parser = gflag.NewParser(&opts, gflag.Default)
 	parser.Usage = "stop POD_ID\n\nStop a running pod"


### PR DESCRIPTION
clean up hyper client command line options a bit:
1. hyper rmi -f defaults to false now, because go-flags does not work well with boolean option defaulting to true, in which case false cannot be specified by users. Besides, hyper does support non-force rmi by rejecting it if there is a pos using the image.
2. remove redundant value-name in bool options. go-flags only use it to generate help message and manpage, where bool option would print its own default value anyway.