### PR TITLE
get tty info from container/info interface

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -202,6 +202,8 @@ func (daemon *Daemon) GetContainerInfo(name string) (types.ContainerInfo, error)
 		i       int = 0
 		imageid string
 		ok      bool
+		cmd     []string
+		args    []string
 	)
 	if name == "" {
 		return types.ContainerInfo{}, fmt.Errorf("Null container name")
@@ -235,6 +237,12 @@ func (daemon *Daemon) GetContainerInfo(name string) (types.ContainerInfo, error)
 				Value: e[strings.Index(e, "=")+1:]})
 		}
 		imageid = jsonResponse.Image
+		cmd = []string{jsonResponse.Path}
+		args = jsonResponse.Args
+	}
+	if len(cmd) == 0 {
+		glog.Warning("length of commands in inspect result should not be zero")
+		cmd = pod.spec.Containers[i].Command
 	}
 	for _, port := range pod.spec.Containers[i].Ports {
 		ports = append(ports, types.ContainerPort{
@@ -284,8 +292,8 @@ func (daemon *Daemon) GetContainerInfo(name string) (types.ContainerInfo, error)
 		PodID:           pod.id,
 		Image:           c.Image,
 		ImageID:         imageid,
-		Commands:        pod.spec.Containers[i].Command,
-		Args:            []string{},
+		Commands:        cmd,
+		Args:            args,
 		Workdir:         pod.spec.Containers[i].Workdir,
 		Ports:           ports,
 		Environment:     envs,

--- a/daemon/podlist.go
+++ b/daemon/podlist.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/hyperhq/runv/hypervisor"
@@ -93,6 +94,27 @@ func (pl *PodList) GetByContainerIdOrName(cid string) (*Pod, int, bool) {
 		if p, ok := pl.pods[podid]; ok {
 			for idx, c := range p.status.Containers {
 				if c.Id == cid {
+					return p, idx, true
+				}
+			}
+		}
+		return nil, -1, false
+	}
+
+	matchPods := []string{}
+	fullId := ""
+	for c, p := range pl.containers {
+		if strings.HasPrefix(c, cid) {
+			matchPods = append(matchPods, p)
+			fullId = c
+		}
+	}
+	if len(matchPods) > 1 {
+		return nil, -1, false
+	} else if len(matchPods) == 1 {
+		if p, ok := pl.pods[matchPods[0]]; ok {
+			for idx, c := range p.status.Containers {
+				if c.Id == fullId {
 					return p, idx, true
 				}
 			}

--- a/types/container.go
+++ b/types/container.go
@@ -57,6 +57,7 @@ type ContainerInfo struct {
 	Ports           []ContainerPort  `json:"ports"`
 	Environment     []EnvironmentVar `json:"env"`
 	Volume          []VolumeMount    `json:"volumeMounts"`
+	Tty             bool             `json:"tty"`
 	ImagePullPolicy string           `json:"imagePullPolicy"`
 	Status          ContainerStatus  `json:"status"`
 }


### PR DESCRIPTION
- support query with container id, prefix, and name (exact id is prefered)
- if there are more than one container share the specified prefix, will return not error

test results:

    [root@h8s-single hyper]# curl http://localhost:9999/v0.5/container/info?container=d29a848c0d58d2660b52d05c6aca2a53d9d464c791e97323c86be7baa3680d3c
    {"name":"/busybox-2919434435","containerID":"d29a848c0d58d2660b52d05c6aca2a53d9d464c791e97323c86be7baa3680d3c","podID":"pod-YPEragSJvS","image":"busybox","imageID":"sha256:3240943c9ea3f72db51bea0a2428e83f3c5fa1312e19af017d026f9bcf70f84b","commands":[],"args":[],"workingDir":"/","ports":[],"env":[],"volumeMounts":[],"tty":false,"imagePullPolicy":"","status":{"name":"busybox-2919434435","containerID":"d29a848c0d58d2660b52d05c6aca2a53d9d464c791e97323c86be7baa3680d3c","phase":"pending","waiting":{"reason":"Pending"},"running":{"startedAt":""},"terminated":{"exitCode":0,"reason":"","message":"","startedAt":"","finishedAt":""}}}
    [root@h8s-single hyper]# curl http://localhost:9999/v0.5/container/info?container=d29a848c0d58d2660b52d05c6aca2a53d9d46
    {"name":"/busybox-2919434435","containerID":"d29a848c0d58d2660b52d05c6aca2a53d9d464c791e97323c86be7baa3680d3c","podID":"pod-YPEragSJvS","image":"busybox","imageID":"sha256:3240943c9ea3f72db51bea0a2428e83f3c5fa1312e19af017d026f9bcf70f84b","commands":[],"args":[],"workingDir":"/","ports":[],"env":[],"volumeMounts":[],"tty":false,"imagePullPolicy":"","status":{"name":"/busybox-2919434435","containerID":"d29a848c0d58d2660b52d05c6aca2a53d9d464c791e97323c86be7baa3680d3c","phase":"pending","waiting":{"reason":"Pending"},"running":{"startedAt":""},"terminated":{"exitCode":0,"reason":"","message":"","startedAt":"","finishedAt":""}}}
    [root@h8s-single hyper]# curl http://localhost:9999/v0.5/container/info?container=busybox-9514458980
    {"name":"/busybox-9514458980","containerID":"3e763bdce0ff9d54c2ec0f03d7a92565bea3f9475197d931cce21e06e388310b","podID":"pod-cKciRfFSVf","image":"busybox","imageID":"sha256:3240943c9ea3f72db51bea0a2428e83f3c5fa1312e19af017d026f9bcf70f84b","commands":["echo","11"],"args":[],"workingDir":"/","ports":[],"env":[],"volumeMounts":[],"tty":false,"imagePullPolicy":"","status":{"name":"/busybox-9514458980","containerID":"3e763bdce0ff9d54c2ec0f03d7a92565bea3f9475197d931cce21e06e388310b","phase":"pending","waiting":{"reason":"Pending"},"running":{"startedAt":""},"terminated":{"exitCode":0,"reason":"","message":"","startedAt":"","finishedAt":""}}}
    [root@h8s-single hyper]# curl http://localhost:9999/v0.5/container/info?container=3
    Can not find container by name(3)
    [root@h8s-single hyper]# curl http://localhost:9999/v0.5/container/info?container=2a0f729a96
    {"name":"/busybox-4951537684","containerID":"2a0f729a963d7b63de8f85a0f1e6ce32c2d9eaee3730ca566d5988dbf0e2000a","podID":"pod-aGqjlBdElE","image":"busybox","imageID":"sha256:3240943c9ea3f72db51bea0a2428e83f3c5fa1312e19af017d026f9bcf70f84b","commands":[],"args":[],"workingDir":"/","ports":[],"env":[],"volumeMounts":[{"name":"etchosts-volume","readOnly":false,"mountPath":"/etc/hosts"}],"tty":true,"imagePullPolicy":"","status":{"name":"/busybox-4951537684","containerID":"2a0f729a963d7b63de8f85a0f1e6ce32c2d9eaee3730ca566d5988dbf0e2000a","phase":"succeeded","waiting":{"reason":""},"running":{"startedAt":""},"terminated":{"exitCode":0,"reason":"Succeeded","message":"","startedAt":"2016-03-17T23:27:26Z","finishedAt":"2016-03-17T23:27:32Z"}}}
    [root@h8s-single hyper]# curl http://localhost:9999/v0.5/container/info?container=aaabbbcc
    Can not find container by name(aaabbbcc)

Signed-off-by: Xu Wang <gnawux@gmail.com>