### PR TITLE
update pod info and container info

### DIFF
--- a/types/container.go
+++ b/types/container.go
@@ -46,18 +46,7 @@ type ContainerStatus struct {
 }
 
 type ContainerInfo struct {
-	Name            string           `json:"name"`
-	ContainerID     string           `json:"containerID"`
-	PodID           string           `json:"podID"`
-	Image           string           `json:"image"`
-	ImageID         string           `json:"imageID"`
-	Commands        []string         `json:"commands"`
-	Args            []string         `json:"args"`
-	Workdir         string           `json:"workingDir"`
-	Ports           []ContainerPort  `json:"ports"`
-	Environment     []EnvironmentVar `json:"env"`
-	Volume          []VolumeMount    `json:"volumeMounts"`
-	Tty             bool             `json:"tty"`
-	ImagePullPolicy string           `json:"imagePullPolicy"`
-	Status          ContainerStatus  `json:"status"`
+	Container
+	PodID  string          `json:"podID"`
+	Status ContainerStatus `json:"status"`
 }

--- a/types/pod.go
+++ b/types/pod.go
@@ -12,6 +12,7 @@ type Container struct {
 	Ports           []ContainerPort  `json:"ports"`
 	Environment     []EnvironmentVar `json:"env"`
 	Volume          []VolumeMount    `json:"volumeMounts"`
+	Tty             bool             `json:"tty"`
 	ImagePullPolicy string           `json:"imagePullPolicy"`
 }
 


### PR DESCRIPTION
- use unify structure for pod and container info
- update cmd and args, as now it comes from inspect
- use image in spec instead of status, as the new status store image id instead of image name in this field

and keeps the /container/info results exactly same as the result in #232

Signed-off-by: Xu Wang <gnawux@gmail.com>