### PR TITLE
Adjust the locking mechanism in daemon

### DIFF
--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -36,9 +36,9 @@ func (daemon *Daemon) Attach(stdin io.ReadCloser, stdout io.WriteCloser, key, id
 		}
 
 		podId = pod.id
-		pod.RLock()
+		pod.Lock()
 		pod.ttyList[tag] = tty
-		pod.RUnlock()
+		pod.Unlock()
 
 		defer func() {
 			if err != nil && pod != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -366,12 +366,11 @@ func (daemon *Daemon) RemoveVm(vmId string) {
 
 func (daemon *Daemon) DestroyAllVm() error {
 	daemon.PodList.Foreach(func(p *Pod) error {
-		if _, _, err := daemon.StopPodWithLock(p.id, "yes"); err != nil {
+		if _, _, err := daemon.StopPodWithinLock(p, "yes"); err != nil {
 			glog.V(1).Infof("fail to stop %s: %v", p.id, err)
 		}
 		return nil
 	})
-	glog.V(2).Infof("unlock PodList")
 	return nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -82,7 +82,7 @@ func (daemon *Daemon) Restore() error {
 	defer daemon.PodList.Unlock()
 
 	for k, v := range podList {
-		_, err = daemon.createPodInternal(k, v, false, true)
+		_, err = daemon.createPodInternal(k, v, true)
 		if err != nil {
 			glog.Warningf("Got a unexpected error, %s", err.Error())
 			continue
@@ -294,7 +294,7 @@ func (daemon *Daemon) WritePodToDB(podName string, podData []byte) error {
 }
 
 // Lock protected
-func (daemon *Daemon) GetPod(podId, podArgs string, autoremove bool) (*Pod, error) {
+func (daemon *Daemon) GetPod(podId, podArgs string) (*Pod, error) {
 	var (
 		pod *Pod
 		ok  bool
@@ -307,7 +307,7 @@ func (daemon *Daemon) GetPod(podId, podArgs string, autoremove bool) (*Pod, erro
 		return pod, nil
 	}
 
-	pod, err := daemon.createPodInternal(podId, podArgs, autoremove, true)
+	pod, err := daemon.createPodInternal(podId, podArgs, true)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/daemonbuilder/pod.go
+++ b/daemon/daemonbuilder/pod.go
@@ -259,7 +259,7 @@ func (d Docker) ContainerCreate(params types.ContainerCreateConfig) (types.Conta
 		return types.ContainerCreateResponse{}, err
 	}
 
-	pod, err := d.Daemon.CreatePod(podId, podString, false)
+	pod, err := d.Daemon.CreatePod(podId, podString)
 	if err != nil {
 		return types.ContainerCreateResponse{}, err
 	}

--- a/daemon/daemondb/daemondb.go
+++ b/daemon/daemondb/daemondb.go
@@ -1,0 +1,231 @@
+package daemondb
+
+import (
+	"strings"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/golang/glog"
+)
+
+type DaemonDB struct {
+	db *leveldb.DB
+}
+
+type KVPair struct {
+	K []byte
+	V []byte
+}
+
+func NewDaemonDB(db_file string) (*DaemonDB, error) {
+	db, err := leveldb.OpenFile(db_file, nil)
+	if err != nil {
+		glog.Errorf("open leveldb file failed, %s", err.Error())
+		return nil, err
+	}
+	return &DaemonDB{ db: db }, nil
+}
+
+// Composition Process
+func (d *DaemonDB) DeleteVMByPod(id string) error {
+	v, err := d.GetP2V(id)
+	if err != nil {
+		return err
+	}
+	d.DeleteP2V(id)
+	if err := d.DeleteVM(v); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Pods podId and args
+func (d *DaemonDB) GetPod(id string) ([]byte, error) {
+	return d.Get(keyPod(id))
+}
+
+func (d *DaemonDB) UpdatePod(id string, data []byte) error {
+	return d.Update(keyPod(id), data)
+}
+
+func (d *DaemonDB) DeletePod(id string) error {
+	return d.db.Delete(keyPod(id), nil)
+}
+
+func (d *DaemonDB) ListPod() ([][]byte, error) {
+	return d.PrefixListKey(prefixPod(), func(key []byte) bool {
+		return !strings.HasPrefix(string(key), POD_CONTAINER_PREFIX)
+	})
+}
+
+func (d *DaemonDB) GetAllPods() chan *KVPair {
+	return d.PrefixList2Chan(prefixPod(), func(key []byte) bool {
+		return !strings.HasPrefix(string(key), POD_CONTAINER_PREFIX)
+	})
+}
+
+// Pod Volumes
+func (d *DaemonDB) UpdatePodVolume(podId, volname string, data []byte) error {
+	return d.Update(keyVolume(podId, volname), data)
+}
+
+func (d *DaemonDB) ListPodVolumes(podId string) ([][]byte, error) {
+	return d.PrefixList(prefixVolume(podId), nil)
+}
+
+func (d *DaemonDB) DeletePodVolumes(podId string) error {
+	return d.PrefixDelete(prefixVolume(podId))
+}
+
+// POD to Containers (string to string list)
+func (d *DaemonDB) GetP2C(id string) ([]string, error) {
+	cl, err := d.Get(keyP2C(id))
+	if err != nil {
+		return []string{}, err
+	}
+	return strings.Split(string(cl), ":"), nil
+}
+
+func (d *DaemonDB) UpdateP2C(id string, containers []string) error {
+	return d.Update(keyP2C(id), []byte(strings.Join(containers, ":")))
+}
+
+func (d *DaemonDB) DeleteP2C(id string) error {
+	return d.db.Delete(keyP2C(id), nil)
+}
+
+// POD to VM (string to string)
+func (d *DaemonDB) GetP2V(id string) (string, error) {
+	return d.GetString(keyP2V(id))
+}
+
+func (d *DaemonDB) UpdateP2V(id, vm string) error {
+	return d.Update(keyP2V(id), []byte(vm))
+}
+
+func (d *DaemonDB) DeleteP2V(id string) error {
+	return d.db.Delete(keyP2V(id), nil)
+}
+
+func (d *DaemonDB) DeleteAllP2V() error {
+	return d.PrefixDelete(prefixP2V())
+}
+
+// VM DATA (string to data)
+func (d *DaemonDB) GetVM(id string) ([]byte, error) {
+	data, err := d.db.Get(keyVMData(id), nil)
+	if err != nil {
+		return []byte(""), err
+	}
+	return data, nil
+}
+
+func (d *DaemonDB) UpdateVM(id string, data []byte) error {
+	return d.Update(keyVMData(id), data)
+}
+
+func (d *DaemonDB) DeleteVM(id string) error {
+	return d.db.Delete(keyVMData(id), nil)
+}
+
+// Low level util
+func (d *DaemonDB) Close() error {
+	return d.db.Close()
+}
+
+func (d *DaemonDB) Get(key []byte) ([]byte, error) {
+	data, err := d.db.Get(key, nil)
+	if err != nil {
+		return []byte(""), err
+	}
+	return data, nil
+}
+
+func (d *DaemonDB) GetString(key []byte) (string, error) {
+	data, err := d.db.Get(key, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (d *DaemonDB) Update(key, data []byte) error {
+	_, err := d.db.Get(key, nil)
+	if err == nil {
+		err = d.db.Delete(key, nil)
+		if err != nil {
+			return err
+		}
+	} else if err != leveldb.ErrNotFound {
+		return err
+	}
+
+	err = d.db.Put(key, data, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DaemonDB) PrefixDelete(prefix []byte) error {
+	iter := d.db.NewIterator(util.BytesPrefix(prefix), nil)
+	for iter.Next() {
+		key := iter.Key()
+		d.db.Delete(key, nil)
+	}
+	iter.Release()
+	err := iter.Error()
+	return err
+}
+
+type KeyFilter func([]byte) bool
+
+func (d *DaemonDB) PrefixList(prefix []byte, keyFilter KeyFilter) ([][]byte, error) {
+	var results [][]byte
+	iter := d.db.NewIterator(util.BytesPrefix(prefix), nil)
+	for iter.Next() {
+		if keyFilter == nil || keyFilter(iter.Key()) {
+			results = append(results, iter.Value())
+		}
+	}
+	iter.Release()
+	err := iter.Error()
+	return results, err
+}
+
+func (d *DaemonDB) PrefixListKey(prefix []byte, keyFilter KeyFilter) ([][]byte, error) {
+	var results [][]byte
+	iter := d.db.NewIterator(util.BytesPrefix(prefix), nil)
+	for iter.Next() {
+		if keyFilter == nil || keyFilter(iter.Key()) {
+			results = append(results, iter.Key())
+		}
+	}
+	iter.Release()
+	err := iter.Error()
+	return results, err
+}
+
+func (d *DaemonDB) PrefixList2Chan(prefix []byte, keyFilter KeyFilter) chan *KVPair {
+	ch := make(chan *KVPair, 128)
+	if ch == nil {
+		return ch
+	}
+	go func() {
+		iter := d.db.NewIterator(util.BytesPrefix(prefix), nil)
+		for iter.Next() {
+			if keyFilter == nil || keyFilter(iter.Key()) {
+				ch <- &KVPair{iter.Key(), iter.Value()}
+			}
+		}
+		iter.Release()
+		if err := iter.Error(); err != nil {
+			ch <- nil
+			glog.Error("Error occurs while iterate db with %v", prefix)
+		}
+		close(ch)
+	}()
+
+	return ch
+}

--- a/daemon/daemondb/daemondb.go
+++ b/daemon/daemondb/daemondb.go
@@ -3,9 +3,9 @@ package daemondb
 import (
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
-	"github.com/golang/glog"
 )
 
 type DaemonDB struct {
@@ -23,7 +23,7 @@ func NewDaemonDB(db_file string) (*DaemonDB, error) {
 		glog.Errorf("open leveldb file failed, %s", err.Error())
 		return nil, err
 	}
-	return &DaemonDB{ db: db }, nil
+	return &DaemonDB{db: db}, nil
 }
 
 // Composition Process

--- a/daemon/daemondb/keys.go
+++ b/daemon/daemondb/keys.go
@@ -1,0 +1,57 @@
+package daemondb
+
+import (
+	"fmt"
+)
+
+const (
+	VM_KEY = "vmdata-%s"
+	POD_KEY = "pod-%s"
+	POD_VM_KEY = "vm-%s"
+	POD_CONTAINER_KEY = "pod-container-%s"
+	POD_VOLUME_KEY = "vol-%s-%s"
+
+	POD_PREFIX = "pod-"
+	POD_CONTAINER_PREFIX = "pod-container-"
+	POD_VOLUME_PREFIX = "vol-%s"
+	POD_VM_PREFIX = "vm-"
+)
+
+//the id is a vm id
+//and the content is vm data content
+func keyVMData(id string) []byte {
+	return []byte(fmt.Sprintf(VM_KEY, id))
+}
+
+// the id is a pod id
+// and the db content is the vm id
+func keyP2V(id string) []byte {
+	return []byte(fmt.Sprintf(POD_VM_KEY, id))
+}
+
+// the id is a pod id
+// and the db containt is the containers separated by comma
+func keyP2C(id string) []byte {
+	return []byte(fmt.Sprintf(POD_CONTAINER_KEY, id))
+}
+
+func keyPod(id string) []byte {
+	return []byte(fmt.Sprintf(POD_KEY, id))
+}
+
+func keyVolume(pod string, volume string) []byte {
+	return []byte(fmt.Sprintf(POD_VOLUME_KEY, pod, volume))
+}
+
+func prefixPod() []byte {
+	return []byte(POD_PREFIX)
+}
+
+func prefixP2V() []byte {
+	return []byte(POD_VM_PREFIX)
+}
+
+// the id is pod id
+func prefixVolume(podId string) []byte {
+	return []byte(fmt.Sprintf(POD_VOLUME_PREFIX, podId))
+}

--- a/daemon/daemondb/keys.go
+++ b/daemon/daemondb/keys.go
@@ -5,16 +5,16 @@ import (
 )
 
 const (
-	VM_KEY = "vmdata-%s"
-	POD_KEY = "pod-%s"
-	POD_VM_KEY = "vm-%s"
+	VM_KEY            = "vmdata-%s"
+	POD_KEY           = "pod-%s"
+	POD_VM_KEY        = "vm-%s"
 	POD_CONTAINER_KEY = "pod-container-%s"
-	POD_VOLUME_KEY = "vol-%s-%s"
+	POD_VOLUME_KEY    = "vol-%s-%s"
 
-	POD_PREFIX = "pod-"
+	POD_PREFIX           = "pod-"
 	POD_CONTAINER_PREFIX = "pod-container-"
-	POD_VOLUME_PREFIX = "vol-%s"
-	POD_VM_PREFIX = "vm-"
+	POD_VOLUME_PREFIX    = "vol-%s"
+	POD_VM_PREFIX        = "vm-"
 )
 
 //the id is a vm id

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -17,9 +17,9 @@ func (daemon *Daemon) ExitCode(container, tag string) (int, error) {
 		return -1, err
 	}
 
-	pod.Lock()
+	pod.RLock()
 	tty, ok := pod.ttyList[tag]
-	defer pod.Unlock()
+	defer pod.RUnlock()
 
 	if !ok {
 		return -1, fmt.Errorf("Tag %s incorrect", tag)

--- a/daemon/graphdriver/vbox/driver.go
+++ b/daemon/graphdriver/vbox/driver.go
@@ -342,7 +342,7 @@ func (d *Driver) VmMountLayer(id string) error {
 		return fmt.Errorf("can not find VM(%s)", d.pullVm)
 	}
 	if vm.Status == types.S_VM_IDLE {
-		code, cause, err := daemon.RunPod(podId, podstring, d.pullVm, nil, false, true, types.VM_KEEP_AFTER_SHUTDOWN, []*hypervisor.TtyIO{})
+		code, cause, err := daemon.RunPod(podId, podstring, d.pullVm, nil, false, types.VM_KEEP_AFTER_SHUTDOWN, []*hypervisor.TtyIO{})
 		if err != nil {
 			glog.Errorf("Code is %d, Cause is %s, %s", code, cause, err.Error())
 			d.daemon.KillVm(d.pullVm)

--- a/daemon/graphdriver/vbox/fsdiff.go
+++ b/daemon/graphdriver/vbox/fsdiff.go
@@ -81,7 +81,7 @@ func (d *Driver) Diff(id, parent string) (diff archive.Archive, err error) {
 		return nil, fmt.Errorf("can not find VM(%s)", d.pullVm)
 	}
 	if vm.Status == types.S_VM_IDLE {
-		code, cause, err = d.daemon.RunPod(podId, podData, d.pullVm, nil, false, true, types.VM_KEEP_AFTER_SHUTDOWN, []*hypervisor.TtyIO{})
+		code, cause, err = d.daemon.RunPod(podId, podData, d.pullVm, nil, false, types.VM_KEEP_AFTER_SHUTDOWN, []*hypervisor.TtyIO{})
 		if err != nil {
 			glog.Errorf("Code is %d, Cause is %s, %s", code, cause, err.Error())
 			d.daemon.KillVm(d.pullVm)

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -14,10 +14,6 @@ import (
 )
 
 func (daemon *Daemon) GetPodInfo(podName string) (types.PodInfo, error) {
-	daemon.PodList.RLock()
-	glog.V(2).Infof("lock read of PodList")
-	defer daemon.PodList.RUnlock()
-	defer glog.V(2).Infof("unlock read of PodList")
 	var (
 		pod     *Pod
 		ok      bool
@@ -170,10 +166,6 @@ func (daemon *Daemon) GetPodInfo(podName string) (types.PodInfo, error) {
 }
 
 func (daemon *Daemon) GetPodStats(podId string) (interface{}, error) {
-	daemon.PodList.RLock()
-	glog.V(2).Infof("lock read of PodList")
-	defer daemon.PodList.RUnlock()
-	defer glog.V(2).Infof("unlock read of PodList")
 	var (
 		pod *Pod
 		ok  bool
@@ -218,18 +210,11 @@ func (daemon *Daemon) GetContainerInfo(name string) (types.ContainerInfo, error)
 	}
 	glog.Infof(name)
 
-	daemon.PodList.RLock()
-	glog.V(2).Infof("lock read of PodList")
-
 	pod, i, ok = daemon.PodList.GetByContainerIdOrName(name)
 	if !ok {
-		daemon.PodList.RUnlock()
-		glog.V(2).Infof("unlock read of PodList")
 		return types.ContainerInfo{}, fmt.Errorf("Can not find container by name(%s)", name)
 	}
 	c = pod.status.Containers[i]
-	daemon.PodList.RUnlock()
-	glog.V(2).Infof("unlock read of PodList")
 
 	ports := []types.ContainerPort{}
 	envs := []types.EnvironmentVar{}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor"
 	"github.com/hyperhq/runv/hypervisor/types"
 )
@@ -20,11 +19,6 @@ func (daemon *Daemon) List(item, podId, vmId string, auxiliary bool) (map[string
 	if item != "pod" && item != "container" && item != "vm" {
 		return list, fmt.Errorf("Can not support %s list!", item)
 	}
-
-	daemon.PodList.RLock()
-	glog.Infof("lock read of PodList")
-	defer glog.Infof("unlock read of PodList")
-	defer daemon.PodList.RUnlock()
 
 	if podId != "" {
 		var ok bool

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -12,6 +12,12 @@ func (daemon Daemon) pausePod(podId string) error {
 	if !ok {
 		return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
 	}
+
+	if !pod.TransitionLock("pause") {
+		return fmt.Errorf("Pod %s is under other operation, please try again later", podId)
+	}
+	defer pod.TransitionUnlock("pause")
+
 	vmId := pod.status.Vm
 
 	vm, ok := daemon.VmList[vmId]
@@ -45,6 +51,12 @@ func (daemon *Daemon) unpausePod(podId string) error {
 	if !ok {
 		return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
 	}
+
+	if !pod.TransitionLock("unpause") {
+		return fmt.Errorf("Pod %s is under other operation, please try again later", podId)
+	}
+	defer pod.TransitionUnlock("unpause")
+
 	vmId := pod.status.Vm
 
 	if pod.status.Status != types.S_POD_PAUSED {

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -8,17 +8,11 @@ import (
 )
 
 func (daemon Daemon) pausePod(podId string) error {
-	daemon.PodList.RLock()
-	glog.V(2).Infof("lock read of PodList")
 	pod, ok := daemon.PodList.Get(podId)
 	if !ok {
-		glog.V(2).Infof("unlock read of PodList")
-		daemon.PodList.RUnlock()
 		return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
 	}
 	vmId := pod.status.Vm
-	glog.V(2).Infof("unlock read of PodList")
-	daemon.PodList.RUnlock()
 
 	vm, ok := daemon.VmList[vmId]
 	if !ok {
@@ -47,17 +41,11 @@ func (daemon Daemon) PauseContainer(container string) error {
 }
 
 func (daemon *Daemon) unpausePod(podId string) error {
-	daemon.PodList.RLock()
-	glog.V(2).Infof("lock read of PodList")
 	pod, ok := daemon.PodList.Get(podId)
 	if !ok {
-		glog.V(2).Infof("unlock read of PodList")
-		daemon.PodList.RUnlock()
 		return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
 	}
 	vmId := pod.status.Vm
-	glog.V(2).Infof("unlock read of PodList")
-	daemon.PodList.RUnlock()
 
 	if pod.status.Status != types.S_POD_PAUSED {
 		return fmt.Errorf("pod is not paused")

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,91 +28,6 @@ import (
 	"github.com/hyperhq/runv/hypervisor/types"
 )
 
-func (daemon *Daemon) StartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId, vmId, tag string) (int, string, error) {
-	// we can only support 1024 Pods
-	if daemon.GetRunningPodNum() >= 1024 {
-		return -1, "", fmt.Errorf("Pod full, the maximum Pod is 1024!")
-	}
-
-	var ttys []*hypervisor.TtyIO = []*hypervisor.TtyIO{}
-
-	if tag != "" {
-		glog.V(1).Info("Pod Run with client terminal tag: ", tag)
-		ttys = append(ttys, &hypervisor.TtyIO{
-			Stdin:     stdin,
-			Stdout:    stdout,
-			ClientTag: tag,
-			Callback:  make(chan *types.VmResponse, 1),
-		})
-	}
-
-	glog.Infof("pod:%s, vm:%s", podId, vmId)
-	// Do the status check for the given pod
-	daemon.PodList.Lock()
-	glog.V(2).Infof("lock PodList")
-
-	p, ok := daemon.PodList.Get(podId)
-	if !ok {
-		glog.V(2).Infof("unlock PodList")
-		daemon.PodList.Unlock()
-		return -1, "", fmt.Errorf("The pod(%s) can not be found, please create it first", podId)
-	}
-	var lazy bool = hypervisor.HDriver.SupportLazyMode() && vmId == ""
-
-	code, cause, err := daemon.StartPodWithLock(p, vmId, nil, lazy, types.VM_KEEP_NONE, ttys)
-	if err != nil {
-		glog.Error(err.Error())
-		glog.V(2).Infof("unlock PodList")
-		daemon.PodList.Unlock()
-		return -1, "", err
-	}
-
-	glog.V(2).Infof("unlock PodList")
-	daemon.PodList.Unlock()
-
-	if len(ttys) > 0 {
-		p.RLock()
-		tty, ok := p.ttyList[tag]
-		p.RUnlock()
-
-		if ok {
-			tty.WaitForFinish()
-		}
-	}
-
-	return code, cause, nil
-}
-
-//create pod if not exist
-func (daemon *Daemon) RunPod(podId, podArgs, vmId string, config interface{}, lazy bool, keep int, streams []*hypervisor.TtyIO) (int, string, error) {
-	daemon.PodList.Lock()
-	glog.V(2).Infof("lock PodList")
-	defer glog.V(2).Infof("unlock PodList")
-	defer daemon.PodList.Unlock()
-	glog.V(1).Infof("podArgs: %s", podArgs)
-
-	p, err := daemon.GetPod(podId, podArgs)
-	if err != nil {
-		return -1, "", err
-	}
-
-	return daemon.StartPodWithLock(p, vmId, config, lazy, keep, streams)
-}
-
-func (daemon *Daemon) StartPodWithLock(p *Pod, vmId string, config interface{}, lazy bool, keep int, streams []*hypervisor.TtyIO) (int, string, error) {
-	if p.vm != nil {
-		return -1, "", fmt.Errorf("pod %s is already running", p.id)
-	}
-
-	vmResponse, err := p.Start(daemon, vmId, lazy, keep, streams)
-	if err != nil {
-		return -1, "", err
-	}
-
-	return vmResponse.Code, vmResponse.Cause, nil
-}
-
-// I'd like to move the remain part of this file to another file.
 type Pod struct {
 	id           string
 	status       *hypervisor.PodStatus
@@ -188,92 +102,6 @@ func (p *Pod) DoCreate(daemon *Daemon) error {
 	}
 
 	if err = p.updateContainerStatus(jsons); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (daemon *Daemon) CreatePod(podId, podArgs string) (*Pod, error) {
-	// we can only support 1024 Pods
-	if daemon.GetRunningPodNum() >= 1024 {
-		return nil, fmt.Errorf("Pod full, the maximum Pod is 1024!")
-	}
-
-	if podId == "" {
-		podId = fmt.Sprintf("pod-%s", pod.RandStr(10, "alpha"))
-	}
-
-	return daemon.createPodInternal(podId, podArgs, false)
-}
-
-func (daemon *Daemon) createPodInternal(podId, podArgs string, withinLock bool) (*Pod, error) {
-	glog.V(2).Infof("podArgs: %s", podArgs)
-
-	pod, err := NewPod([]byte(podArgs), podId, daemon)
-	if err != nil {
-		return nil, err
-	}
-
-	// Creation
-	if err = pod.DoCreate(daemon); err != nil {
-		return nil, err
-	}
-
-	if !withinLock {
-		daemon.PodList.Lock()
-		glog.V(2).Infof("lock PodList")
-		defer glog.V(2).Infof("unlock PodList")
-		defer daemon.PodList.Unlock()
-	}
-
-	if err = daemon.AddPod(pod, podArgs); err != nil {
-		return nil, err
-	}
-
-	return pod, nil
-}
-
-func (daemon *Daemon) SetPodLabels(podId string, override bool, labels map[string]string) error {
-	daemon.PodList.RLock()
-	glog.V(2).Infof("lock read of PodList")
-	defer daemon.PodList.RUnlock()
-	defer glog.V(2).Infof("unlock read of PodList")
-
-	var pod *Pod
-	if strings.Contains(podId, "pod-") {
-		var ok bool
-		pod, ok = daemon.PodList.Get(podId)
-		if !ok {
-			return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
-		}
-	} else {
-		pod = daemon.PodList.GetByName(podId)
-		if pod == nil {
-			return fmt.Errorf("Can not get Pod info with pod name(%s)", podId)
-		}
-	}
-
-	if pod.spec.Labels == nil {
-		pod.spec.Labels = make(map[string]string)
-	}
-
-	for k := range labels {
-		if _, ok := pod.spec.Labels[k]; ok && !override {
-			return fmt.Errorf("Can't update label %s without override", k)
-		}
-	}
-
-	for k, v := range labels {
-		pod.spec.Labels[k] = v
-	}
-
-	spec, err := json.Marshal(pod.spec)
-	if err != nil {
-		return err
-	}
-
-	if err := daemon.db.UpdatePod(pod.id, spec); err != nil {
 		return err
 	}
 
@@ -1032,54 +860,22 @@ func (p *Pod) Start(daemon *Daemon, vmId string, lazy bool, keep int, streams []
 	return vmResponse, nil
 }
 
-// The caller must make sure that the restart policy and the status is right to restart
-func (daemon *Daemon) RestartPod(mypod *hypervisor.PodStatus) error {
-	// Remove the pod
-	// The pod is stopped, the vm is gone
-	daemon.CleanUpContainer(mypod)
-	daemon.RemovePod(mypod.Id)
-	daemon.DeleteVolumeId(mypod.Id)
-
-	podData, err := daemon.db.GetPod(mypod.Id)
-	if err != nil {
-		return err
-	}
-	var lazy bool = hypervisor.HDriver.SupportLazyMode()
-
-	// Start the pod
-	_, _, err = daemon.RunPod(mypod.Id, string(podData), "", nil, lazy, types.VM_KEEP_NONE, []*hypervisor.TtyIO{})
-	if err != nil {
-		glog.Error(err.Error())
-		return err
-	}
-
-	if err := daemon.WritePodAndContainers(mypod.Id); err != nil {
-		glog.Error("Found an error while saving the Containers info")
-		return err
-	}
-
-	return nil
-}
-
 func hyperHandlePodEvent(vmResponse *types.VmResponse, data interface{},
 	mypod *hypervisor.PodStatus, vm *hypervisor.Vm) bool {
 	daemon := data.(*Daemon)
 
-	if vmResponse.Code == types.E_POD_FINISHED {
-		if vm.Keep != types.VM_KEEP_NONE {
-			vm.Status = types.S_VM_IDLE
-			return false
-		}
+	switch vmResponse.Code {
+	case types.E_POD_FINISHED: // successfully exit
 		stopLogger(mypod)
 		mypod.SetPodContainerStatus(vmResponse.Data.([]uint32))
 		vm.Status = types.S_VM_IDLE
-	} else if vmResponse.Code == types.E_VM_SHUTDOWN {
-		if mypod.Status == types.S_POD_RUNNING {
+		return false
+	case types.E_VM_SHUTDOWN: // vm exited, sucessful or not
+		if mypod.Status == types.S_POD_RUNNING { // not received finished pod before
 			stopLogger(mypod)
-			mypod.Status = types.S_POD_SUCCEEDED
-			mypod.SetContainerStatus(types.S_POD_SUCCEEDED)
+			mypod.Status = types.S_POD_FAILED
+			mypod.SetContainerStatus(types.S_POD_FAILED)
 		}
-		mypod.Vm = ""
 		daemon.PodStopped(mypod.Id)
 		if mypod.Type == "kubernetes" {
 			cleanup := false
@@ -1100,12 +896,15 @@ func hyperHandlePodEvent(vmResponse *types.VmResponse, data interface{},
 				break
 			}
 			if cleanup {
-				daemon.CleanUpContainer(mypod)
+				pod, ok := daemon.PodList.Get(mypod.Id)
+				if ok {
+					daemon.RemovePodContainer(pod)
+				}
 				daemon.DeleteVolumeId(mypod.Id)
 			}
 		}
 		return true
+	default:
+		return false
 	}
-
-	return false
 }

--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -337,7 +337,7 @@ func (p *Pod) tryLoadContainers(daemon *Daemon) ([]*dockertypes.ContainerJSON, e
 		ok             bool
 	)
 
-	if ids, _ := daemon.GetPodContainersByName(p.id); ids != nil {
+	if ids, _ := daemon.GetPodContainersByPod(p.id); ids != nil {
 		containerNames := make(map[string]int)
 
 		for idx, c := range p.spec.Containers {
@@ -1039,7 +1039,7 @@ func (daemon *Daemon) RestartPod(mypod *hypervisor.PodStatus) error {
 	daemon.RemovePod(mypod.Id)
 	daemon.DeleteVolumeId(mypod.Id)
 
-	podData, err := daemon.GetPodByName(mypod.Id)
+	podData, err := daemon.GetPodFromDB(mypod.Id)
 	if err != nil {
 		return err
 	}

--- a/daemon/podlist.go
+++ b/daemon/podlist.go
@@ -61,7 +61,7 @@ func (pl *PodList) Delete(id string) {
 
 func (pl *PodList) GetByName(name string) *Pod {
 	pl.mu.RLock()
-	defer pl.mu.Unlock()
+	defer pl.mu.RUnlock()
 
 	return pl.findUnsafe(func(p *Pod) bool {
 		if p.status.Name == name {
@@ -73,7 +73,7 @@ func (pl *PodList) GetByName(name string) *Pod {
 
 func (pl *PodList) GetByContainerId(cid string) (*Pod, bool) {
 	pl.mu.RLock()
-	defer pl.mu.Unlock()
+	defer pl.mu.RUnlock()
 
 	if pl.pods == nil {
 		return nil, false
@@ -101,7 +101,7 @@ func (pl *PodList) GetByContainerId(cid string) (*Pod, bool) {
 
 func (pl *PodList) GetByContainerIdOrName(cid string) (*Pod, int, bool) {
 	pl.mu.RLock()
-	defer pl.mu.Unlock()
+	defer pl.mu.RUnlock()
 
 	if pl.pods == nil {
 		return nil, 0, false

--- a/daemon/podlist.go
+++ b/daemon/podlist.go
@@ -11,17 +11,20 @@ import (
 type PodList struct {
 	pods       map[string]*Pod
 	containers map[string]string
-	sync.RWMutex
+	mu         *sync.RWMutex
 }
 
 func NewPodList() *PodList {
 	return &PodList{
 		pods:       make(map[string]*Pod),
 		containers: make(map[string]string),
+		mu:         &sync.RWMutex{},
 	}
 }
 
 func (pl *PodList) Get(id string) (*Pod, bool) {
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
 	if pl.pods == nil {
 		return nil, false
 	}
@@ -30,6 +33,8 @@ func (pl *PodList) Get(id string) (*Pod, bool) {
 }
 
 func (pl *PodList) Put(p *Pod) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
 	if pl.pods == nil {
 		pl.pods = make(map[string]*Pod)
 	}
@@ -44,6 +49,8 @@ func (pl *PodList) Put(p *Pod) {
 }
 
 func (pl *PodList) Delete(id string) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
 	if p, ok := pl.pods[id]; ok {
 		for _, c := range p.status.Containers {
 			delete(pl.containers, c.Id)
@@ -53,7 +60,10 @@ func (pl *PodList) Delete(id string) {
 }
 
 func (pl *PodList) GetByName(name string) *Pod {
-	return pl.Find(func(p *Pod) bool {
+	pl.mu.RLock()
+	defer pl.mu.Unlock()
+
+	return pl.findUnsafe(func(p *Pod) bool {
 		if p.status.Name == name {
 			return true
 		}
@@ -62,6 +72,9 @@ func (pl *PodList) GetByName(name string) *Pod {
 }
 
 func (pl *PodList) GetByContainerId(cid string) (*Pod, bool) {
+	pl.mu.RLock()
+	defer pl.mu.Unlock()
+
 	if pl.pods == nil {
 		return nil, false
 	}
@@ -70,7 +83,7 @@ func (pl *PodList) GetByContainerId(cid string) (*Pod, bool) {
 		return p, ok
 	}
 
-	pod := pl.Find(func(p *Pod) bool {
+	pod := pl.findUnsafe(func(p *Pod) bool {
 		for _, c := range p.status.Containers {
 			if c.Id == cid {
 				return true
@@ -87,6 +100,9 @@ func (pl *PodList) GetByContainerId(cid string) (*Pod, bool) {
 }
 
 func (pl *PodList) GetByContainerIdOrName(cid string) (*Pod, int, bool) {
+	pl.mu.RLock()
+	defer pl.mu.Unlock()
+
 	if pl.pods == nil {
 		return nil, 0, false
 	}
@@ -128,7 +144,7 @@ func (pl *PodList) GetByContainerIdOrName(cid string) (*Pod, int, bool) {
 		wslash = "/" + cid
 	}
 
-	pod := pl.Find(func(p *Pod) bool {
+	pod := pl.findUnsafe(func(p *Pod) bool {
 		for i, c := range p.status.Containers {
 			if c.Id == cid || c.Name == wslash {
 				idx = i
@@ -159,8 +175,8 @@ func (pl *PodList) CountRunning() int64 {
 func (pl *PodList) CountStatus(status uint) (num int64) {
 	num = 0
 
-	pl.RLock()
-	defer pl.RUnlock()
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
 
 	if pl.pods == nil {
 		return
@@ -177,8 +193,8 @@ func (pl *PodList) CountStatus(status uint) (num int64) {
 
 func (pl *PodList) CountContainers() (num int64) {
 	num = 0
-	pl.RLock()
-	defer pl.RUnlock()
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
 
 	if pl.pods == nil {
 		return
@@ -195,6 +211,12 @@ type PodOp func(*Pod) error
 type PodFilterOp func(*Pod) bool
 
 func (pl *PodList) Foreach(fn PodOp) error {
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
+	return pl.foreachUnsafe(fn)
+}
+
+func (pl *PodList) foreachUnsafe(fn PodOp) error {
 	for _, p := range pl.pods {
 		if err := fn(p); err != nil {
 			return err
@@ -204,6 +226,12 @@ func (pl *PodList) Foreach(fn PodOp) error {
 }
 
 func (pl *PodList) Find(fn PodFilterOp) *Pod {
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
+	return pl.findUnsafe(fn)
+}
+
+func (pl *PodList) findUnsafe(fn PodFilterOp) *Pod {
 	for _, p := range pl.pods {
 		if fn(p) {
 			return p

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -1,18 +1,9 @@
 package daemon
 
-import (
-	"github.com/golang/glog"
-)
-
 func (daemon *Daemon) ContainerRename(oldname, newname string) error {
 	if err := daemon.Daemon.ContainerRename(oldname, newname); err != nil {
 		return err
 	}
-
-	daemon.PodList.RLock()
-	glog.V(2).Infof("lock read of PodList")
-	defer glog.V(2).Infof("unlock read of PodList")
-	defer daemon.PodList.RUnlock()
 
 	daemon.PodList.Find(func(p *Pod) bool {
 		for _, c := range p.status.Containers {

--- a/daemon/rm.go
+++ b/daemon/rm.go
@@ -28,8 +28,6 @@ func (daemon *Daemon) CleanPodWithLock(podId string) (int, string, error) {
 		err   error
 	)
 
-	os.RemoveAll(path.Join(utils.HYPER_ROOT, "services", podId))
-	os.RemoveAll(path.Join(utils.HYPER_ROOT, "hosts", podId))
 	pod, ok := daemon.PodList.Get(podId)
 	if !ok {
 		return -1, "", fmt.Errorf("Can not find that Pod(%s)", podId)
@@ -42,7 +40,10 @@ func (daemon *Daemon) CleanPodWithLock(podId string) (int, string, error) {
 		}
 	}
 
-	daemon.DeletePodFromDB(podId)
+	os.RemoveAll(path.Join(utils.HYPER_ROOT, "services", podId))
+	os.RemoveAll(path.Join(utils.HYPER_ROOT, "hosts", podId))
+
+	daemon.db.DeletePod(podId)
 	daemon.RemovePod(podId)
 	if pod.status.Type != "kubernetes" {
 		daemon.CleanUpContainer(pod.status)
@@ -60,5 +61,5 @@ func (daemon *Daemon) CleanUpContainer(ps *hypervisor.PodStatus) {
 			glog.Warningf("Error to rm container: %s", err.Error())
 		}
 	}
-	daemon.DeletePodContainerFromDB(ps.Id)
+	daemon.db.DeleteP2C(ps.Id)
 }

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -97,6 +97,11 @@ func (daemon *Daemon) StartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId
 }
 
 func (daemon *Daemon) StartInternal(p *Pod, vmId string, config interface{}, lazy bool, keep int, streams []*hypervisor.TtyIO) (int, string, error) {
+	if !p.TransitionLock("start") {
+		return -1, "", fmt.Errorf("The pod(%s) is operting by others, please retry later", p.id)
+	}
+	defer p.TransitionUnlock("start")
+
 	if p.vm != nil {
 		return -1, "", fmt.Errorf("pod %s is already running", p.id)
 	}

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -1,0 +1,184 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/hyperhq/runv/hypervisor"
+	"github.com/hyperhq/runv/hypervisor/pod"
+	"github.com/hyperhq/runv/hypervisor/types"
+
+	"github.com/golang/glog"
+)
+
+func (daemon *Daemon) CreatePod(podId, podArgs string) (*Pod, error) {
+	// we can only support 1024 Pods
+	if daemon.GetRunningPodNum() >= 1024 {
+		return nil, fmt.Errorf("Pod full, the maximum Pod is 1024!")
+	}
+
+	if podId == "" {
+		podId = fmt.Sprintf("pod-%s", pod.RandStr(10, "alpha"))
+	}
+
+	p, err := daemon.createPodInternal(podId, podArgs, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = daemon.AddPod(p, podArgs); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (daemon *Daemon) createPodInternal(podId, podArgs string, withinLock bool) (*Pod, error) {
+	glog.V(2).Infof("podArgs: %s", podArgs)
+
+	pod, err := NewPod([]byte(podArgs), podId, daemon)
+	if err != nil {
+		return nil, err
+	}
+
+	// Creation
+	if err = pod.DoCreate(daemon); err != nil {
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+func (daemon *Daemon) StartPod(stdin io.ReadCloser, stdout io.WriteCloser, podId, vmId, tag string) (int, string, error) {
+	// we can only support 1024 Pods
+	if daemon.GetRunningPodNum() >= 1024 {
+		return -1, "", fmt.Errorf("Pod full, the maximum Pod is 1024!")
+	}
+
+	var ttys []*hypervisor.TtyIO = []*hypervisor.TtyIO{}
+
+	if tag != "" {
+		glog.V(1).Info("Pod Run with client terminal tag: ", tag)
+		ttys = append(ttys, &hypervisor.TtyIO{
+			Stdin:     stdin,
+			Stdout:    stdout,
+			ClientTag: tag,
+			Callback:  make(chan *types.VmResponse, 1),
+		})
+	}
+
+	glog.Infof("pod:%s, vm:%s", podId, vmId)
+
+	p, ok := daemon.PodList.Get(podId)
+	if !ok {
+		return -1, "", fmt.Errorf("The pod(%s) can not be found, please create it first", podId)
+	}
+	var lazy bool = hypervisor.HDriver.SupportLazyMode() && vmId == ""
+
+	code, cause, err := daemon.StartInternal(p, vmId, nil, lazy, types.VM_KEEP_NONE, ttys)
+	if err != nil {
+		glog.Error(err.Error())
+		return -1, "", err
+	}
+
+	if len(ttys) > 0 {
+		p.RLock()
+		tty, ok := p.ttyList[tag]
+		p.RUnlock()
+
+		if ok {
+			tty.WaitForFinish()
+		}
+	}
+
+	return code, cause, nil
+}
+
+func (daemon *Daemon) StartInternal(p *Pod, vmId string, config interface{}, lazy bool, keep int, streams []*hypervisor.TtyIO) (int, string, error) {
+	if p.vm != nil {
+		return -1, "", fmt.Errorf("pod %s is already running", p.id)
+	}
+
+	vmResponse, err := p.Start(daemon, vmId, lazy, keep, streams)
+	if err != nil {
+		return -1, "", err
+	}
+
+	return vmResponse.Code, vmResponse.Cause, nil
+}
+
+// The caller must make sure that the restart policy and the status is right to restart
+func (daemon *Daemon) RestartPod(mypod *hypervisor.PodStatus) error {
+	// Remove the pod
+	// The pod is stopped, the vm is gone
+	pod, ok := daemon.PodList.Get(mypod.Id)
+	if ok {
+		daemon.RemovePodContainer(pod)
+	}
+	daemon.RemovePod(mypod.Id)
+	daemon.DeleteVolumeId(mypod.Id)
+
+	podData, err := daemon.db.GetPod(mypod.Id)
+	if err != nil {
+		return err
+	}
+	var lazy bool = hypervisor.HDriver.SupportLazyMode()
+
+	// Start the pod
+	pnew, err := daemon.CreatePod(pod.id, string(podData))
+	if err != nil {
+		glog.Errorf(err.Error())
+		return err
+	}
+	_, _, err = daemon.StartInternal(pnew, "", nil, lazy, types.VM_KEEP_NONE, []*hypervisor.TtyIO{})
+	if err != nil {
+		glog.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func (daemon *Daemon) SetPodLabels(podId string, override bool, labels map[string]string) error {
+
+	var pod *Pod
+	if strings.Contains(podId, "pod-") {
+		var ok bool
+		pod, ok = daemon.PodList.Get(podId)
+		if !ok {
+			return fmt.Errorf("Can not get Pod info with pod ID(%s)", podId)
+		}
+	} else {
+		pod = daemon.PodList.GetByName(podId)
+		if pod == nil {
+			return fmt.Errorf("Can not get Pod info with pod name(%s)", podId)
+		}
+	}
+
+	if pod.spec.Labels == nil {
+		pod.spec.Labels = make(map[string]string)
+	}
+
+	for k := range labels {
+		if _, ok := pod.spec.Labels[k]; ok && !override {
+			return fmt.Errorf("Can't update label %s without override", k)
+		}
+	}
+
+	for k, v := range labels {
+		pod.spec.Labels[k] = v
+	}
+
+	spec, err := json.Marshal(pod.spec)
+	if err != nil {
+		return err
+	}
+
+	if err := daemon.db.UpdatePod(pod.id, spec); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -189,7 +189,7 @@ func (daemon *Daemon) CmdStartPod(stdin io.ReadCloser, stdout io.WriteCloser, po
 
 //FIXME: there was a `config` argument passed by docker/builder, but we never processed it.
 func (daemon *Daemon) CmdCreatePod(podArgs string, autoremove bool) (*engine.Env, error) {
-	p, err := daemon.CreatePod("", podArgs, autoremove)
+	p, err := daemon.CreatePod("", podArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/servicediscovery.go
+++ b/daemon/servicediscovery.go
@@ -123,21 +123,17 @@ func (daemon *Daemon) GetServices(podId string) ([]pod.UserService, error) {
 }
 
 func (daemon *Daemon) GetServiceContainerInfo(podId string) (*hypervisor.Vm, string, error) {
-	daemon.PodList.RLock()
 	pod, ok := daemon.PodList.Get(podId)
 	if !ok {
-		daemon.PodList.RUnlock()
 		return nil, "", fmt.Errorf("Cannot find Pod %s", podId)
 	}
 
 	if pod.status.Type != "service-discovery" || len(pod.status.Containers) <= 1 {
-		daemon.PodList.RUnlock()
 		return nil, "", fmt.Errorf("Pod %s doesn't have services discovery", podId)
 	}
 
 	container := pod.status.Containers[0].Id
 	glog.V(1).Infof("Get container id is %s", container)
-	daemon.PodList.RUnlock()
 
 	if pod.vm == nil {
 		return nil, "", fmt.Errorf("Can find VM for %s!", podId)

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -8,7 +8,9 @@ import (
 
 func (daemon *Daemon) PodStopped(podId string) {
 	// find the vm id which running POD, and stop it
+	daemon.PodList.RLock()
 	pod, ok := daemon.PodList.Get(podId)
+	daemon.PodList.RUnlock()
 	if !ok {
 		glog.Errorf("Can not find pod(%s)", podId)
 		return

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -8,14 +8,13 @@ import (
 
 func (daemon *Daemon) PodStopped(podId string) {
 	// find the vm id which running POD, and stop it
-	daemon.PodList.RLock()
 	pod, ok := daemon.PodList.Get(podId)
-	daemon.PodList.RUnlock()
 	if !ok {
 		glog.Errorf("Can not find pod(%s)", podId)
 		return
 	}
 
+	pod.status.Vm = ""
 	if pod.vm == nil {
 		return
 	}
@@ -26,10 +25,6 @@ func (daemon *Daemon) PodStopped(podId string) {
 }
 
 func (daemon *Daemon) StopPod(podId, stopVm string) (int, string, error) {
-	daemon.PodList.Lock()
-	glog.V(2).Infof("lock PodList")
-	defer glog.V(2).Infof("unlock PodList")
-	defer daemon.PodList.Unlock()
 
 	return daemon.StopPodWithLock(podId, stopVm)
 }

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -20,9 +20,6 @@ func (daemon *Daemon) PodStopped(podId string) {
 
 	daemon.DeleteVmByPod(podId)
 	daemon.RemoveVm(pod.vm.Id)
-	if pod.status.Autoremove == true {
-		daemon.CleanPod(podId)
-	}
 	pod.vm = nil
 }
 
@@ -61,9 +58,6 @@ func (daemon *Daemon) StopPodWithLock(podId, stopVm string) (int, string, error)
 
 	if vmResponse.Code == types.E_VM_SHUTDOWN {
 		daemon.RemoveVm(vmId)
-	}
-	if pod.status.Autoremove == true {
-		daemon.CleanPodWithLock(podId)
 	}
 	pod.vm = nil
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) PodStopped(podId string) {
 		return
 	}
 
-	daemon.DeleteVmByPod(podId)
+	daemon.db.DeleteVMByPod(podId)
 	daemon.RemoveVm(pod.vm.Id)
 	pod.vm = nil
 }
@@ -56,7 +56,7 @@ func (daemon *Daemon) StopPodWithLock(podId, stopVm string) (int, string, error)
 	vmResponse := pod.vm.StopPod(pod.status, stopVm)
 
 	// Delete the Vm info for POD
-	daemon.DeleteVmByPod(podId)
+	daemon.db.DeleteVMByPod(podId)
 
 	if vmResponse.Code == types.E_VM_SHUTDOWN {
 		daemon.RemoveVm(vmId)

--- a/daemon/storage.go
+++ b/daemon/storage.go
@@ -197,7 +197,7 @@ func (dms *DevMapperStorage) CreateVolume(daemon *Daemon, podId, shortName strin
 		}
 
 		glog.V(3).Infof("device (%d) created (restore:%v) for %s: %s", dev_id, restore, podId, volName)
-		daemon.SetVolumeId(podId, volName, dev_id_str)
+		daemon.db.UpdatePodVolume(podId, volName, []byte(fmt.Sprintf("%s:%s", volName, dev_id_str)))
 		break
 	}
 

--- a/daemon/vm.go
+++ b/daemon/vm.go
@@ -56,7 +56,7 @@ func (p *Pod) AssociateVm(daemon *Daemon, vmId string) error {
 		return nil
 	}
 
-	vmData, err := daemon.GetVmData(vmId)
+	vmData, err := daemon.db.GetVM(vmId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- pod list lock is dedicated for pod list internal access now
- set pod return status success only if the pod return with all 0 value, i.e. set failed if user stop it. and some other stop processing adjustment
- move the demon methods about create/start pod to a new file
- move all leveldb code to daemondb package, and remove unnecessary daemon method for those have in daemondb
- remove some old flag or methods, including autoremove, GetPod/RunPod
