### PR TITLE
container: store mountid to container info

### DIFF
--- a/daemon/pod.go
+++ b/daemon/pod.go
@@ -326,7 +326,8 @@ func (p *Pod) parseContainerJsons(daemon *Daemon, jsons []*dockertypes.Container
 			return errors.New(estr)
 		}
 
-		ci.Id = mountId
+		ci.Id = info.ID
+		ci.MountId = mountId
 		ci.Workdir = info.Config.WorkingDir
 		ci.Cmd = append([]string{info.Path}, info.Args...)
 
@@ -645,7 +646,7 @@ func (p *Pod) setupMountsAndFiles(sd Storage) (err error) {
 			ci *hypervisor.ContainerInfo
 		)
 
-		mountId := p.ctnStartInfo[i].Id
+		mountId := p.ctnStartInfo[i].MountId
 		glog.Infof("container ID: %s, mountId %s\n", c.Id, mountId)
 		ci, err = sd.PrepareContainer(mountId, sharedDir)
 		if err != nil {

--- a/daemon/storage.go
+++ b/daemon/storage.go
@@ -163,10 +163,10 @@ func (dms *DevMapperStorage) PrepareContainer(id, sharedDir string) (*hypervisor
 		fstype = "ext4"
 	}
 	return &hypervisor.ContainerInfo{
-		Id:     id,
-		Rootfs: "/rootfs",
-		Image:  devFullName,
-		Fstype: fstype,
+		MountId: id,
+		Rootfs:  "/rootfs",
+		Image:   devFullName,
+		Fstype:  fstype,
 	}, nil
 }
 
@@ -264,10 +264,10 @@ func (a *AufsStorage) PrepareContainer(id, sharedDir string) (*hypervisor.Contai
 	}
 	devFullName := "/" + id + "/rootfs"
 	return &hypervisor.ContainerInfo{
-		Id:     id,
-		Rootfs: "",
-		Image:  devFullName,
-		Fstype: "dir",
+		MountId: id,
+		Rootfs:  "",
+		Image:   devFullName,
+		Fstype:  "dir",
 	}, nil
 }
 
@@ -322,10 +322,10 @@ func (o *OverlayFsStorage) PrepareContainer(id, sharedDir string) (*hypervisor.C
 	}
 	devFullName := "/" + id + "/rootfs"
 	return &hypervisor.ContainerInfo{
-		Id:     id,
-		Rootfs: "",
-		Image:  devFullName,
-		Fstype: "dir",
+		MountId: id,
+		Rootfs:  "",
+		Image:   devFullName,
+		Fstype:  "dir",
 	}, nil
 }
 
@@ -379,10 +379,10 @@ func (v *VBoxStorage) PrepareContainer(id, sharedDir string) (*hypervisor.Contai
 		return nil, err
 	}
 	return &hypervisor.ContainerInfo{
-		Id:     id,
-		Rootfs: "/rootfs",
-		Image:  devFullName,
-		Fstype: "ext4",
+		MountId: id,
+		Rootfs:  "/rootfs",
+		Image:   devFullName,
+		Fstype:  "ext4",
 	}, nil
 }
 


### PR DESCRIPTION
based on https://github.com/hyperhq/runv/pull/149

inspect container is removed in start, so store mountid to
make sure get the correct mountid.

Signed-off-by: Gao feng <omarapazanadi@gmail.com>