### PR TITLE
for non-tty container, write log should use stdcopy

### DIFF
--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/golang/glog"
 	"github.com/hyperhq/runv/hypervisor/types"
 )
@@ -41,6 +42,11 @@ func (daemon *Daemon) GetContainerLogs(container string, config *ContainerLogsCo
 	pod, cidx, err = daemon.GetPodByContainerIdOrName(container)
 	if err != nil {
 		return err
+	}
+
+	if !pod.spec.Containers[cidx].Tty {
+		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
+		errStream = stdcopy.NewStdWriter(config.OutStream, stdcopy.Stderr)
 	}
 
 	err = pod.getLogger(daemon)


### PR DESCRIPTION
This is the behavior compatible to docker(tm). However, because hyperctl
always try using stream as tty terminal. Need further modification on hyperctl.
should we do the further improvement in another PR?

Signed-off-by: Xu Wang <gnawux@gmail.com>